### PR TITLE
Add payroll PDF exports for payslips and reports

### DIFF
--- a/Controllers/PayrollController.cs
+++ b/Controllers/PayrollController.cs
@@ -1,9 +1,12 @@
 using System.Globalization;
+using System.IO;
+using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using TrackHive.Models;
+using TrackHive.Services;
 
 namespace TrackHive.Controllers;
 
@@ -11,10 +14,15 @@ namespace TrackHive.Controllers;
 public sealed class PayrollController : Controller
 {
     private readonly AppDbContext _db;
+    private readonly PayrollPdfGenerator _pdfGenerator;
     private const decimal StandardDailyHours = 8m;
     private const decimal DefaultOvertimeMultiplier = 1.5m;
 
-    public PayrollController(AppDbContext db) => _db = db;
+    public PayrollController(AppDbContext db, PayrollPdfGenerator pdfGenerator)
+    {
+        _db = db;
+        _pdfGenerator = pdfGenerator;
+    }
 
     [HttpGet]
     public async Task<IActionResult> Index(int? employeeId = null, int? year = null, int? month = null)
@@ -49,6 +57,8 @@ public sealed class PayrollController : Controller
                 alertType = "warning";
             }
         }
+
+        ApplyTempAlert(ref alertMessage, ref alertType);
 
         var viewModel = new PayrollIndexViewModel
         {
@@ -138,6 +148,8 @@ public sealed class PayrollController : Controller
             history = await LoadHistoryAsync(form.SelectedEmployeeId.Value);
         }
 
+        ApplyTempAlert(ref alertMessage, ref alertType);
+
         var viewModel = new PayrollIndexViewModel
         {
             Employees = employees,
@@ -150,6 +162,267 @@ public sealed class PayrollController : Controller
 
         return View("Index", viewModel);
     }
+
+    [HttpGet]
+    public async Task<IActionResult> DownloadPayslip(int employeeId, int year, int month)
+    {
+        var hr = await GetCurrentUserAsync();
+        if (hr is null) return RedirectToAction("Login", "Auth");
+        if (hr.MustChangePassword) return RedirectToAction("ChangePassword", "Auth");
+
+        var form = new PayrollCalculationForm
+        {
+            SelectedEmployeeId = employeeId,
+            Year = year,
+            Month = month,
+            ManualDeductions = 0m,
+            AdditionalOvertimeHours = 0m
+        };
+
+        var routeValues = new { employeeId, year, month };
+
+        var result = await TryCreatePayslipAsync(hr, form, allowRecalculation: false);
+        if (result.Document is null)
+        {
+            if (!string.IsNullOrEmpty(result.ErrorMessage))
+            {
+                SetTempAlert(result.ErrorMessage, result.AlertType);
+            }
+
+            return RedirectToAction("Index", routeValues);
+        }
+
+        return CreatePayslipFile(result.Document, year, month);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DownloadPayslip(PayrollCalculationForm form)
+    {
+        var hr = await GetCurrentUserAsync();
+        if (hr is null) return RedirectToAction("Login", "Auth");
+        if (hr.MustChangePassword) return RedirectToAction("ChangePassword", "Auth");
+
+        var routeValues = new { employeeId = form.SelectedEmployeeId, year = form.Year, month = form.Month };
+
+        var result = await TryCreatePayslipAsync(hr, form, allowRecalculation: true);
+        if (result.Document is null)
+        {
+            if (!string.IsNullOrEmpty(result.ErrorMessage))
+            {
+                SetTempAlert(result.ErrorMessage, result.AlertType);
+            }
+
+            return RedirectToAction("Index", routeValues);
+        }
+
+        return CreatePayslipFile(result.Document, form.Year, form.Month);
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> DownloadReport(int year, int month)
+    {
+        var hr = await GetCurrentUserAsync();
+        if (hr is null) return RedirectToAction("Login", "Auth");
+        if (hr.MustChangePassword) return RedirectToAction("ChangePassword", "Auth");
+
+        if (year < 2000 || year > 2100 || month < 1 || month > 12)
+        {
+            SetTempAlert("Choose a valid month and year to export the payroll report.", "warning");
+            return RedirectToAction("Index", new { year, month });
+        }
+
+        var records = await _db.PayrollRecords
+            .AsNoTracking()
+            .Include(r => r.User)
+            .Where(r => r.Year == year && r.Month == month && r.User != null && r.User.OrganizationId == hr.OrganizationId)
+            .OrderBy(r => r.User!.Name)
+            .ToListAsync();
+
+        if (records.Count == 0)
+        {
+            var label = new DateTime(year, month, 1).ToString("MMMM yyyy", CultureInfo.InvariantCulture);
+            SetTempAlert($"No payroll records found for {label}.", "warning");
+            return RedirectToAction("Index", new { year, month });
+        }
+
+        var organization = await _db.Organizations.AsNoTracking().FirstOrDefaultAsync(o => o.Id == hr.OrganizationId);
+        if (organization is null)
+        {
+            return NotFound();
+        }
+
+        var entries = records
+            .Select(r => new PayrollReportEntry(
+                r.User!.Name,
+                r.User.Email,
+                r.GrossPay,
+                r.NetPay,
+                r.Deductions,
+                r.OvertimePay,
+                r.TotalOvertimeHours,
+                r.WorkingDays,
+                r.PresentDays,
+                r.CalculatedAt))
+            .ToList();
+
+        var model = new PayrollReportDocumentModel(organization.Name, year, month, DateTimeOffset.UtcNow, entries);
+
+        var pdf = _pdfGenerator.GenerateMonthlyReport(model);
+        var safeOrg = SanitizeFileName(model.OrganizationName);
+        var fileName = $"{safeOrg}_{year}-{month:00}_PayrollReport.pdf";
+
+        return File(pdf, "application/pdf", fileName);
+    }
+
+    private void SetTempAlert(string message, string type)
+    {
+        TempData["PayrollAlert.Message"] = message;
+        TempData["PayrollAlert.Type"] = type;
+    }
+
+    private void ApplyTempAlert(ref string? message, ref string alertType)
+    {
+        if (TempData.TryGetValue("PayrollAlert.Message", out var storedMessageObj) && storedMessageObj is string storedMessage && !string.IsNullOrWhiteSpace(storedMessage))
+        {
+            message ??= storedMessage;
+            if (TempData.TryGetValue("PayrollAlert.Type", out var storedTypeObj) && storedTypeObj is string storedType && !string.IsNullOrWhiteSpace(storedType))
+            {
+                alertType = storedType;
+            }
+        }
+    }
+
+    private FileContentResult CreatePayslipFile(PayslipDocumentModel document, int year, int month)
+    {
+        var pdf = _pdfGenerator.GeneratePayslip(document);
+        var safeOrg = SanitizeFileName(document.OrganizationName);
+        var safeEmployee = SanitizeFileName(document.EmployeeName);
+        var fileName = $"{safeOrg}_{safeEmployee}_{year}-{month:00}_Payslip.pdf";
+        return File(pdf, "application/pdf", fileName);
+    }
+
+    private async Task<PayslipGenerationResult> TryCreatePayslipAsync(AppUser hr, PayrollCalculationForm form, bool allowRecalculation)
+    {
+        if (form.SelectedEmployeeId is null)
+        {
+            return new PayslipGenerationResult(null, "Select an employee to generate a payslip.", "warning");
+        }
+
+        if (form.Year < 2000 || form.Year > 2100 || form.Month < 1 || form.Month > 12)
+        {
+            return new PayslipGenerationResult(null, "Choose a valid month and year for the payslip.", "warning");
+        }
+
+        if (form.ManualDeductions < 0 || form.AdditionalOvertimeHours < 0)
+        {
+            return new PayslipGenerationResult(null, "Deductions and overtime hours cannot be negative.", "warning");
+        }
+
+        var employee = await _db.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Id == form.SelectedEmployeeId.Value && u.OrganizationId == hr.OrganizationId && u.Role == RoleType.Employee);
+
+        if (employee is null)
+        {
+            return new PayslipGenerationResult(null, "Employee not found.", "danger");
+        }
+
+        var organization = await _db.Organizations.AsNoTracking().FirstOrDefaultAsync(o => o.Id == hr.OrganizationId);
+        if (organization is null)
+        {
+            return new PayslipGenerationResult(null, "Organization not found.", "danger");
+        }
+
+        var periodLabel = new DateTime(form.Year, form.Month, 1).ToString("MMMM yyyy", CultureInfo.InvariantCulture);
+
+        var record = await _db.PayrollRecords
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.UserId == employee.Id && r.Year == form.Year && r.Month == form.Month);
+
+        if (record is not null)
+        {
+            var absentDays = Math.Max(record.WorkingDays - record.PresentDays, 0);
+            var document = new PayslipDocumentModel(
+                organization.Name,
+                employee.Name,
+                employee.Email,
+                periodLabel,
+                record.CalculatedAt,
+                record.MonthlySalary,
+                record.WorkingDays,
+                record.PresentDays,
+                absentDays,
+                record.StandardHours,
+                record.WorkedHours,
+                record.HourlyRate,
+                record.AutoOvertimeHours,
+                record.AdditionalOvertimeHours,
+                record.TotalOvertimeHours,
+                record.OvertimeMultiplier,
+                record.AttendancePay,
+                record.OvertimePay,
+                record.Deductions,
+                record.GrossPay,
+                record.NetPay);
+
+            return new PayslipGenerationResult(document, null, "success");
+        }
+
+        if (!allowRecalculation)
+        {
+            return new PayslipGenerationResult(null, $"No saved payroll record found for {periodLabel}.", "warning");
+        }
+
+        var calculation = await BuildCalculationAsync(hr.OrganizationId, employee.Id, form.Year, form.Month, form.ManualDeductions, form.AdditionalOvertimeHours);
+        if (calculation is null)
+        {
+            return new PayslipGenerationResult(null, "Unable to calculate the payslip for the selected period.", "danger");
+        }
+
+        var calculatedDocument = new PayslipDocumentModel(
+            organization.Name,
+            calculation.EmployeeName,
+            employee.Email,
+            calculation.PeriodLabel,
+            DateTimeOffset.UtcNow,
+            calculation.MonthlySalary,
+            calculation.WorkingDays,
+            calculation.PresentDays,
+            calculation.AbsentDays,
+            calculation.StandardHours,
+            calculation.WorkedHours,
+            calculation.HourlyRate,
+            calculation.AutoOvertimeHours,
+            calculation.ManualOvertimeHours,
+            calculation.TotalOvertimeHours,
+            calculation.OvertimeMultiplier,
+            calculation.AttendancePay,
+            calculation.OvertimePay,
+            calculation.Deductions,
+            calculation.GrossPay,
+            calculation.NetPay);
+
+        return new PayslipGenerationResult(calculatedDocument, null, "success");
+    }
+
+    private static string SanitizeFileName(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "document";
+        }
+
+        var sanitized = value.Replace(' ', '_');
+        foreach (var invalid in Path.GetInvalidFileNameChars())
+        {
+            sanitized = sanitized.Replace(invalid, '_');
+        }
+
+        return sanitized;
+    }
+
+    private sealed record PayslipGenerationResult(PayslipDocumentModel? Document, string? ErrorMessage, string AlertType);
 
     private async Task<AppUser?> GetCurrentUserAsync()
     {

--- a/Program.cs
+++ b/Program.cs
@@ -3,9 +3,13 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using QuestPDF.Infrastructure;
 using TrackHive.Models;
+using TrackHive.Services;
 
 var builder = WebApplication.CreateBuilder(args);
+
+Settings.License = LicenseType.Community;
 
 // MVC + global MustChangePassword filter
 builder.Services.AddControllersWithViews(options =>
@@ -32,6 +36,7 @@ builder.Services.AddAuthorization();
 builder.Services.Configure<SmtpOptions>(builder.Configuration.GetSection("Smtp"));
 builder.Services.AddTransient<EmailService>();
 builder.Services.AddScoped<MustChangePasswordFilter>();
+builder.Services.AddSingleton<PayrollPdfGenerator>();
 
 var app = builder.Build();
 

--- a/Services/PayrollPdfGenerator.cs
+++ b/Services/PayrollPdfGenerator.cs
@@ -1,0 +1,380 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
+namespace TrackHive.Services;
+
+public sealed class PayrollPdfGenerator
+{
+    private static readonly CultureInfo Culture = CultureInfo.InvariantCulture;
+
+    public byte[] GeneratePayslip(PayslipDocumentModel data)
+    {
+        var document = Document.Create(container =>
+        {
+            container.Page(page =>
+            {
+                page.Size(PageSizes.A4);
+                page.Margin(40);
+                page.DefaultTextStyle(style => style.FontSize(11));
+
+                page.Header().Element(header => BuildPayslipHeader(header, data));
+                page.Content().Element(content => BuildPayslipContent(content, data));
+                page.Footer().AlignCenter().Text(text =>
+                {
+                    text.Span($"Generated on {FormatDate(data.GeneratedAt)} · Page ");
+                    text.CurrentPageNumber();
+                    text.Span(" of ");
+                    text.TotalPages();
+                }).FontSize(9).FontColor(Colors.Grey.Medium);
+            });
+        });
+
+        return document.GeneratePdf();
+    }
+
+    public byte[] GenerateMonthlyReport(PayrollReportDocumentModel data)
+    {
+        var document = Document.Create(container =>
+        {
+            container.Page(page =>
+            {
+                page.Size(PageSizes.A4);
+                page.Margin(40);
+                page.DefaultTextStyle(style => style.FontSize(10));
+
+                page.Header().Element(header => BuildReportHeader(header, data));
+                page.Content().Element(content => BuildReportContent(content, data));
+                page.Footer().AlignCenter().Text(text =>
+                {
+                    text.Span($"Generated on {FormatDate(data.GeneratedAt)} · Page ");
+                    text.CurrentPageNumber();
+                    text.Span(" of ");
+                    text.TotalPages();
+                }).FontSize(9).FontColor(Colors.Grey.Medium);
+            });
+        });
+
+        return document.GeneratePdf();
+    }
+
+    private static void BuildPayslipHeader(IContainer container, PayslipDocumentModel data)
+    {
+        container.Row(row =>
+        {
+            row.RelativeColumn().Column(column =>
+            {
+                column.Item().Text(data.OrganizationName)
+                    .FontSize(20)
+                    .SemiBold();
+
+                column.Item().Text("Official payslip")
+                    .FontSize(12)
+                    .FontColor(Colors.Grey.Darken2);
+
+                column.Item().Text(data.PeriodLabel)
+                    .FontSize(12)
+                    .FontColor(Colors.Grey.Darken1);
+            });
+
+            row.ConstantColumn(160).AlignRight().Column(column =>
+            {
+                column.Item().Text("Net pay")
+                    .FontSize(11)
+                    .SemiBold()
+                    .FontColor(Colors.Grey.Darken2);
+
+                column.Item().Text(FormatCurrency(data.NetPay))
+                    .FontSize(22)
+                    .Bold()
+                    .FontColor(Colors.Green.Darken2);
+            });
+        });
+    }
+
+    private static void BuildPayslipContent(IContainer container, PayslipDocumentModel data)
+    {
+        container.Column(column =>
+        {
+            column.Spacing(14);
+
+            column.Item().Border(1).BorderColor(Colors.Grey.Lighten2).Padding(14).Column(section =>
+            {
+                section.Spacing(6);
+                section.Item().Text("Employee details").SemiBold();
+                section.Item().Text(data.EmployeeName);
+
+                if (!string.IsNullOrWhiteSpace(data.EmployeeEmail))
+                {
+                    section.Item().Text(data.EmployeeEmail)
+                        .FontColor(Colors.Grey.Darken1)
+                        .FontSize(10);
+                }
+
+                section.Item().PaddingTop(8).Row(row =>
+                {
+                    row.RelativeColumn().Text("Pay period");
+                    row.ConstantColumn(200).AlignRight().Text(data.PeriodLabel);
+                });
+
+                section.Item().Row(row =>
+                {
+                    row.RelativeColumn().Text("Generated");
+                    row.ConstantColumn(200).AlignRight().Text(FormatDate(data.GeneratedAt));
+                });
+            });
+
+            column.Item().Border(1).BorderColor(Colors.Grey.Lighten2).Padding(14).Column(section =>
+            {
+                section.Spacing(6);
+                section.Item().Text("Attendance summary").SemiBold();
+                section.Item().Table(table =>
+                {
+                    table.ColumnsDefinition(columns =>
+                    {
+                        columns.RelativeColumn();
+                        columns.ConstantColumn(120);
+                    });
+
+                    AddTableRow(table, "Working days", data.WorkingDays.ToString(Culture));
+                    AddTableRow(table, "Present days", data.PresentDays.ToString(Culture));
+                    AddTableRow(table, "Absent days", data.AbsentDays.ToString(Culture));
+                    AddTableRow(table, "Standard hours", FormatHours(data.StandardHours));
+                    AddTableRow(table, "Worked hours", FormatHours(data.WorkedHours));
+                    AddTableRow(table, "Hourly rate", FormatCurrency(data.HourlyRate));
+                });
+            });
+
+            column.Item().Border(1).BorderColor(Colors.Grey.Lighten2).Padding(14).Column(section =>
+            {
+                section.Spacing(6);
+                section.Item().Text("Overtime breakdown").SemiBold();
+                section.Item().Table(table =>
+                {
+                    table.ColumnsDefinition(columns =>
+                    {
+                        columns.RelativeColumn();
+                        columns.ConstantColumn(120);
+                    });
+
+                    AddTableRow(table, "Automatic overtime (hrs)", FormatHours(data.AutoOvertimeHours));
+                    AddTableRow(table, "Manual overtime (hrs)", FormatHours(data.ManualOvertimeHours));
+                    AddTableRow(table, "Total overtime (hrs)", FormatHours(data.TotalOvertimeHours));
+                    AddTableRow(table, "Overtime multiplier", $"{data.OvertimeMultiplier:N2}×");
+                    AddTableRow(table, "Overtime pay", FormatCurrency(data.OvertimePay));
+                });
+            });
+
+            column.Item().Border(1).BorderColor(Colors.Grey.Lighten2).Padding(14).Column(section =>
+            {
+                section.Spacing(6);
+                section.Item().Text("Compensation").SemiBold();
+                section.Item().Table(table =>
+                {
+                    table.ColumnsDefinition(columns =>
+                    {
+                        columns.RelativeColumn();
+                        columns.ConstantColumn(120);
+                    });
+
+                    AddTableRow(table, "Monthly salary", FormatCurrency(data.MonthlySalary));
+                    AddTableRow(table, "Attendance pay", FormatCurrency(data.AttendancePay));
+                    AddTableRow(table, "Overtime pay", FormatCurrency(data.OvertimePay));
+                    AddTableRow(table, "Deductions", FormatCurrency(data.Deductions));
+                    AddTableRow(table, "Gross pay", FormatCurrency(data.GrossPay));
+                });
+            });
+
+            column.Item().Background(Colors.Green.Lighten5).Border(1).BorderColor(Colors.Green.Lighten2).Padding(16).Row(row =>
+            {
+                row.RelativeColumn().Column(section =>
+                {
+                    section.Item().Text("Net pay").FontSize(12).SemiBold();
+                    section.Item().Text(FormatCurrency(data.NetPay)).FontSize(20).Bold();
+                });
+
+                row.ConstantColumn(200).AlignRight().Column(section =>
+                {
+                    section.Item().Text("Take-home summary")
+                        .FontSize(10)
+                        .FontColor(Colors.Grey.Darken1);
+
+                    section.Item().Text(text =>
+                    {
+                        text.Span("Gross").FontColor(Colors.Grey.Darken1);
+                        text.Span($": {FormatCurrency(data.GrossPay)}");
+                        text.Line($"Deductions: {FormatCurrency(data.Deductions)}");
+                    }).FontSize(10);
+                });
+            });
+        });
+    }
+
+    private static void BuildReportHeader(IContainer container, PayrollReportDocumentModel data)
+    {
+        container.Column(column =>
+        {
+            column.Item().Text(data.OrganizationName)
+                .FontSize(20)
+                .SemiBold();
+
+            column.Item().Text($"Payroll report · {data.PeriodLabel}")
+                .FontSize(12)
+                .FontColor(Colors.Grey.Darken2);
+
+            column.Item().Text($"Employees included: {data.Records.Count}")
+                .FontSize(10)
+                .FontColor(Colors.Grey.Darken1);
+        });
+    }
+
+    private static void BuildReportContent(IContainer container, PayrollReportDocumentModel data)
+    {
+        var grossTotal = data.Records.Sum(r => r.GrossPay);
+        var netTotal = data.Records.Sum(r => r.NetPay);
+        var deductionTotal = data.Records.Sum(r => r.Deductions);
+        var overtimeTotal = data.Records.Sum(r => r.OvertimePay);
+
+        container.Column(column =>
+        {
+            column.Spacing(12);
+
+            column.Item().Table(table =>
+            {
+                table.ColumnsDefinition(columns =>
+                {
+                    columns.RelativeColumn(3);
+                    columns.RelativeColumn();
+                    columns.RelativeColumn();
+                    columns.RelativeColumn();
+                    columns.RelativeColumn();
+                    columns.RelativeColumn(2);
+                });
+
+                table.Header(header =>
+                {
+                    header.Cell().Element(CellHeaderStyle).Text("Employee");
+                    header.Cell().Element(CellHeaderStyle).AlignRight().Text("Gross");
+                    header.Cell().Element(CellHeaderStyle).AlignRight().Text("Net");
+                    header.Cell().Element(CellHeaderStyle).AlignRight().Text("Deductions");
+                    header.Cell().Element(CellHeaderStyle).AlignRight().Text("Overtime");
+                    header.Cell().Element(CellHeaderStyle).Text("Generated");
+                });
+
+                foreach (var record in data.Records)
+                {
+                    table.Cell().Element(CellStyle).Text(text =>
+                    {
+                        text.Span(record.EmployeeName).SemiBold();
+                        if (!string.IsNullOrWhiteSpace(record.EmployeeEmail))
+                        {
+                            text.Line(record.EmployeeEmail).FontSize(9).FontColor(Colors.Grey.Darken1);
+                        }
+
+                        text.Line($"Attendance: {record.PresentDays}/{record.WorkingDays} days")
+                            .FontSize(9)
+                            .FontColor(Colors.Grey.Darken1);
+                    });
+
+                    table.Cell().Element(CellStyle).AlignRight().Text(FormatCurrency(record.GrossPay));
+                    table.Cell().Element(CellStyle).AlignRight().Text(FormatCurrency(record.NetPay));
+                    table.Cell().Element(CellStyle).AlignRight().Text(FormatCurrency(record.Deductions));
+                    table.Cell().Element(CellStyle).AlignRight().Text(text =>
+                    {
+                        text.Span(FormatCurrency(record.OvertimePay));
+                        text.Line($"{record.TotalOvertimeHours:N2} hrs").FontSize(9).FontColor(Colors.Grey.Darken1);
+                    });
+                    table.Cell().Element(CellStyle).Text(FormatDate(record.CalculatedAt));
+                }
+            });
+
+            column.Item().BorderTop(1).BorderColor(Colors.Grey.Lighten2).PaddingTop(8).Row(row =>
+            {
+                row.RelativeColumn().Text("Totals").SemiBold();
+                row.RelativeColumn().AlignRight().Text(FormatCurrency(grossTotal));
+                row.RelativeColumn().AlignRight().Text(FormatCurrency(netTotal));
+                row.RelativeColumn().AlignRight().Text(FormatCurrency(deductionTotal));
+                row.RelativeColumn().AlignRight().Text(FormatCurrency(overtimeTotal));
+                row.RelativeColumn(2).Text($"Report generated: {FormatDate(data.GeneratedAt)}")
+                    .FontSize(9)
+                    .FontColor(Colors.Grey.Darken1);
+            });
+        });
+    }
+
+    private static void AddTableRow(TableDescriptor table, string label, string value)
+    {
+        table.Cell().Element(CellStyle).Text(label);
+        table.Cell().Element(CellStyle).AlignRight().Text(value);
+    }
+
+    private static IContainer CellStyle(IContainer container)
+    {
+        return container.BorderBottom(1)
+            .BorderColor(Colors.Grey.Lighten4)
+            .PaddingVertical(6);
+    }
+
+    private static IContainer CellHeaderStyle(IContainer container)
+    {
+        return container.Background(Colors.Grey.Lighten4)
+            .PaddingVertical(6)
+            .PaddingHorizontal(4)
+            .BorderBottom(1)
+            .BorderColor(Colors.Grey.Lighten2);
+    }
+
+    private static string FormatCurrency(decimal value) => string.Format(Culture, "${0:N2}", value);
+
+    private static string FormatHours(decimal value) => value.ToString("N2", Culture);
+
+    private static string FormatDate(DateTimeOffset value) => value.ToLocalTime().ToString("f", Culture);
+}
+
+public sealed record PayslipDocumentModel(
+    string OrganizationName,
+    string EmployeeName,
+    string EmployeeEmail,
+    string PeriodLabel,
+    DateTimeOffset GeneratedAt,
+    decimal MonthlySalary,
+    int WorkingDays,
+    int PresentDays,
+    int AbsentDays,
+    decimal StandardHours,
+    decimal WorkedHours,
+    decimal HourlyRate,
+    decimal AutoOvertimeHours,
+    decimal ManualOvertimeHours,
+    decimal TotalOvertimeHours,
+    decimal OvertimeMultiplier,
+    decimal AttendancePay,
+    decimal OvertimePay,
+    decimal Deductions,
+    decimal GrossPay,
+    decimal NetPay);
+
+public sealed record PayrollReportDocumentModel(
+    string OrganizationName,
+    int Year,
+    int Month,
+    DateTimeOffset GeneratedAt,
+    IReadOnlyList<PayrollReportEntry> Records)
+{
+    public string PeriodLabel => new DateTime(Year, Month, 1).ToString("MMMM yyyy", CultureInfo.InvariantCulture);
+}
+
+public sealed record PayrollReportEntry(
+    string EmployeeName,
+    string EmployeeEmail,
+    decimal GrossPay,
+    decimal NetPay,
+    decimal Deductions,
+    decimal OvertimePay,
+    decimal TotalOvertimeHours,
+    int WorkingDays,
+    int PresentDays,
+    DateTimeOffset CalculatedAt);

--- a/TrackHive.csproj
+++ b/TrackHive.csproj
@@ -17,6 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="QuestPDF" Version="2024.8.3" />
   </ItemGroup>
 
 

--- a/Views/Payroll/Index.cshtml
+++ b/Views/Payroll/Index.cshtml
@@ -1,10 +1,14 @@
+@using System.Linq
 @model TrackHive.Models.PayrollIndexViewModel
-@{
+@{ 
     ViewData["Title"] = "Payroll Calculator";
     Layout = "~/Views/Shared/_Layout.App.cshtml";
 
     string FormatHours(decimal value) => string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:N2}", value);
     string FormatDays(int value) => value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+    var invariant = System.Globalization.CultureInfo.InvariantCulture;
+    bool HasSavedRecord(TrackHive.Models.PayrollCalculationResult value) =>
+        Model.History.Any(h => h.Year == value.Year && h.Month == value.Month);
 }
 
 <div class="row g-4">
@@ -128,6 +132,22 @@
                         </div>
                     </div>
 
+                    @{ var hasSavedRecord = HasSavedRecord(result); }
+                    <div class="d-flex flex-wrap gap-2 align-items-center mb-4">
+                        <form asp-action="DownloadPayslip" asp-controller="Payroll" method="post" class="d-inline">
+                            @Html.AntiForgeryToken()
+                            <input type="hidden" name="SelectedEmployeeId" value="@result.EmployeeId" />
+                            <input type="hidden" name="Year" value="@Model.Form.Year" />
+                            <input type="hidden" name="Month" value="@Model.Form.Month" />
+                            <input type="hidden" name="ManualDeductions" value="@Model.Form.ManualDeductions.ToString(invariant)" />
+                            <input type="hidden" name="AdditionalOvertimeHours" value="@Model.Form.AdditionalOvertimeHours.ToString(invariant)" />
+                            <button type="submit" class="btn btn-outline-primary">Download payslip (PDF)</button>
+                        </form>
+                        <span class="text-secondary small">
+                            @(hasSavedRecord ? "Uses the stored payroll record for this period." : "Exports the current calculation if no saved record exists.")
+                        </span>
+                    </div>
+
                     <div class="table-responsive mb-4">
                         <table class="table table-sm align-middle">
                             <thead>
@@ -210,7 +230,14 @@
     <div class="col-12 col-xl-5">
         <div class="card shadow-sm">
             <div class="card-body p-4">
-                <h2 class="h6 mb-3">Recent payroll history</h2>
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <h2 class="h6 mb-0">Recent payroll history</h2>
+                    <a class="btn btn-sm btn-outline-secondary"
+                       asp-action="DownloadReport"
+                       asp-controller="Payroll"
+                       asp-route-year="@Model.Form.Year"
+                       asp-route-month="@Model.Form.Month">Export report (PDF)</a>
+                </div>
                 @if (Model.History.Count == 0)
                 {
                     <p class="text-secondary mb-0">No payroll records saved yet.</p>
@@ -225,6 +252,7 @@
                                     <th scope="col" class="text-end">Net pay</th>
                                     <th scope="col" class="text-end">Gross</th>
                                     <th scope="col" class="text-end">Deducted</th>
+                                    <th scope="col" class="text-end">Payslip</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -238,6 +266,21 @@
                                         <td class="text-end">@string.Format("${0:N2}", record.NetPay)</td>
                                         <td class="text-end text-secondary">@string.Format("${0:N2}", record.GrossPay)</td>
                                         <td class="text-end text-danger">@string.Format("${0:N2}", record.Deductions)</td>
+                                        <td class="text-end">
+                                            @if (Model.Form.SelectedEmployeeId.HasValue)
+                                            {
+                                                <a class="btn btn-sm btn-outline-secondary"
+                                                   asp-action="DownloadPayslip"
+                                                   asp-controller="Payroll"
+                                                   asp-route-employeeId="@Model.Form.SelectedEmployeeId"
+                                                   asp-route-year="@record.Year"
+                                                   asp-route-month="@record.Month">Payslip</a>
+                                            }
+                                            else
+                                            {
+                                                <span class="text-secondary">—</span>
+                                            }
+                                        </td>
                                     </tr>
                                 }
                             </tbody>


### PR DESCRIPTION
## Summary
- integrate QuestPDF and a reusable generator to build payslip and payroll report PDFs
- add controller endpoints and UI hooks for one-click payslip downloads and monthly payroll exports
- register the PDF service and display alerts when exports are unavailable

## Testing
- dotnet build *(fails: `dotnet` CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca35d4cbc883289264f2aa6f5ac56f