### PR TITLE
Adjust PDF footer styling for QuestPDF

### DIFF
--- a/Services/PayrollPdfGenerator.cs
+++ b/Services/PayrollPdfGenerator.cs
@@ -23,13 +23,15 @@ public sealed class PayrollPdfGenerator
 
                 page.Header().Element(header => BuildPayslipHeader(header, data));
                 page.Content().Element(content => BuildPayslipContent(content, data));
-                page.Footer().AlignCenter().Text(text =>
-                {
-                    text.Span($"Generated on {FormatDate(data.GeneratedAt)} · Page ");
-                    text.CurrentPageNumber();
-                    text.Span(" of ");
-                    text.TotalPages();
-                }).FontSize(9).FontColor(Colors.Grey.Medium);
+                page.Footer().AlignCenter()
+                    .DefaultTextStyle(style => style.FontSize(9).FontColor(Colors.Grey.Medium))
+                    .Text(text =>
+                    {
+                        text.Span($"Generated on {FormatDate(data.GeneratedAt)} · Page ");
+                        text.CurrentPageNumber();
+                        text.Span(" of ");
+                        text.TotalPages();
+                    });
             });
         });
 
@@ -48,13 +50,15 @@ public sealed class PayrollPdfGenerator
 
                 page.Header().Element(header => BuildReportHeader(header, data));
                 page.Content().Element(content => BuildReportContent(content, data));
-                page.Footer().AlignCenter().Text(text =>
-                {
-                    text.Span($"Generated on {FormatDate(data.GeneratedAt)} · Page ");
-                    text.CurrentPageNumber();
-                    text.Span(" of ");
-                    text.TotalPages();
-                }).FontSize(9).FontColor(Colors.Grey.Medium);
+                page.Footer().AlignCenter()
+                    .DefaultTextStyle(style => style.FontSize(9).FontColor(Colors.Grey.Medium))
+                    .Text(text =>
+                    {
+                        text.Span($"Generated on {FormatDate(data.GeneratedAt)} · Page ");
+                        text.CurrentPageNumber();
+                        text.Span(" of ");
+                        text.TotalPages();
+                    });
             });
         });
 
@@ -204,10 +208,10 @@ public sealed class PayrollPdfGenerator
 
                     section.Item().Text(text =>
                     {
-                        text.Span("Gross").FontColor(Colors.Grey.Darken1);
-                        text.Span($": {FormatCurrency(data.GrossPay)}");
-                        text.Line($"Deductions: {FormatCurrency(data.Deductions)}");
-                    }).FontSize(10);
+                        text.Span("Gross").FontColor(Colors.Grey.Darken1).FontSize(10);
+                        text.Span($": {FormatCurrency(data.GrossPay)}").FontSize(10);
+                        text.Line($"Deductions: {FormatCurrency(data.Deductions)}").FontSize(10);
+                    });
                 });
             });
         });


### PR DESCRIPTION
## Summary
- apply footer text styles via the container before rendering content to avoid chaining font methods on Text descriptors
- move the take-home summary font sizing to the individual spans inside the text block

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ca3efddbec83288c4fc7cee9606baf