### PR TITLE
Fix overtime multiplier literal

### DIFF
--- a/Views/Payroll/Index.cshtml
+++ b/Views/Payroll/Index.cshtml
@@ -183,7 +183,7 @@
                                 </tr>
                                 <tr>
                                     <td>Overtime multiplier</td>
-                                    <td class="text-end">@result.OvertimeMultiplier.ToString("0.##")x</td>
+                                    <td class="text-end">@($"{result.OvertimeMultiplier:0.##}x")</td>
                                 </tr>
                             </tbody>
                         </table>


### PR DESCRIPTION
## Summary
- adjust the overtime multiplier display so the literal x is outside the Razor expression

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ca3f002fd88328ac426bc5d2ecbd6c