### PR TITLE
Add automated HR notifications

### DIFF
--- a/Controllers/HrDashboardController.cs
+++ b/Controllers/HrDashboardController.cs
@@ -229,6 +229,7 @@ public sealed class HrDashboardController : Controller
         return await _db.Users.FindAsync(id);
     }
 
+
     private async Task<HrDashboardViewModel> BuildDashboardViewModelAsync(AppUser hr, InviteEmployeeViewModel? inviteOverride)
     {
         var org = await _db.Organizations.AsNoTracking().FirstOrDefaultAsync(o => o.Id == hr.OrganizationId);
@@ -300,12 +301,133 @@ public sealed class HrDashboardController : Controller
             })
             .ToList();
 
+        var notifications = new List<DashboardNotificationViewModel>();
+        var employeeNameLookup = employees.ToDictionary(e => e.Id, e => e.Name);
+
+        if (pendingViewModels.Count > 0)
+        {
+            var oldestPending = pendingRequests.Min(r => r.CreatedAt);
+            notifications.Add(new DashboardNotificationViewModel
+            {
+                Category = "Leave",
+                Title = "Pending leave approvals",
+                Message = $"You have {pendingViewModels.Count} leave request(s) waiting for review.",
+                CreatedAt = oldestPending
+            });
+        }
+
+        if (employeeIds.Count > 0)
+        {
+            var statusHistoryCutoff = DateTimeOffset.UtcNow.AddDays(-7);
+            var recentDecisions = await _db.LeaveRequests
+                .AsNoTracking()
+                .Include(r => r.User)
+                .Where(r => employeeIds.Contains(r.UserId)
+                    && r.Status != LeaveRequestStatus.Pending
+                    && r.ReviewedAt != null
+                    && r.ReviewedAt >= statusHistoryCutoff)
+                .OrderByDescending(r => r.ReviewedAt)
+                .Take(5)
+                .ToListAsync();
+
+            foreach (var decision in recentDecisions)
+            {
+                var status = decision.Status == LeaveRequestStatus.Approved ? "approved" : "rejected";
+                var reviewedAt = decision.ReviewedAt!.Value;
+                var employeeName = decision.User?.Name ?? "Employee";
+                notifications.Add(new DashboardNotificationViewModel
+                {
+                    Category = "Leave",
+                    Title = $"{employeeName}'s leave {status}",
+                    Message = $"{employeeName}'s {decision.TotalDays} day(s) of leave were {status} on {reviewedAt.ToLocalTime():MMM d}.",
+                    CreatedAt = reviewedAt
+                });
+            }
+
+            var lateThreshold = new TimeOnly(9, 30).ToTimeSpan();
+            var attendanceWindowStart = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-6));
+            var recentAttendance = await _db.AttendanceRecords
+                .AsNoTracking()
+                .Where(a => employeeIds.Contains(a.UserId)
+                    && a.Date >= attendanceWindowStart
+                    && a.CheckInTime != null)
+                .Select(a => new { a.UserId, a.Date, a.CheckInTime })
+                .ToListAsync();
+
+            static bool IsLate(DateTimeOffset checkInLocal, TimeSpan threshold) => checkInLocal.TimeOfDay > threshold;
+
+            var lateArrivals = recentAttendance
+                .Select(a => new
+                {
+                    a.UserId,
+                    a.Date,
+                    CheckInLocal = a.CheckInTime!.Value.ToLocalTime()
+                })
+                .Where(a => IsLate(a.CheckInLocal, lateThreshold))
+                .OrderByDescending(a => a.Date)
+                .ThenByDescending(a => a.CheckInLocal)
+                .Take(5)
+                .ToList();
+
+            foreach (var record in lateArrivals)
+            {
+                if (!employeeNameLookup.TryGetValue(record.UserId, out var employeeName))
+                {
+                    employeeName = "Employee";
+                }
+
+                var checkInLocal = record.CheckInLocal.ToLocalTime();
+                notifications.Add(new DashboardNotificationViewModel
+                {
+                    Category = "Attendance",
+                    Title = "Late arrival alert",
+                    Message = $"{employeeName} checked in at {checkInLocal:t} on {record.Date:MMM d}.",
+                    CreatedAt = record.CheckInLocal
+                });
+            }
+
+            var today = DateOnly.FromDateTime(DateTime.UtcNow);
+            var monthStart = new DateOnly(today.Year, today.Month, 1);
+            var nextMonth = monthStart.AddMonths(1);
+            var monthAttendance = await _db.AttendanceRecords
+                .AsNoTracking()
+                .Where(a => employeeIds.Contains(a.UserId)
+                    && a.Date >= monthStart
+                    && a.Date < nextMonth)
+                .Select(a => new { a.UserId, a.Date, a.CheckInTime })
+                .ToListAsync();
+
+            if (monthAttendance.Count > 0)
+            {
+                var totalCheckIns = monthAttendance.Count(a => a.CheckInTime != null);
+                var employeesActive = monthAttendance.Select(a => a.UserId).Distinct().Count();
+                var lateCount = monthAttendance
+                    .Where(a => a.CheckInTime != null)
+                    .Select(a => a.CheckInTime!.Value.ToLocalTime())
+                    .Count(local => IsLate(local, lateThreshold));
+
+                notifications.Add(new DashboardNotificationViewModel
+                {
+                    Category = "Reports",
+                    Title = $"{monthStart:MMMM yyyy} attendance summary",
+                    Message = $"{totalCheckIns} check-in(s) recorded across {employeesActive} employee(s) with {lateCount} late arrival(s).",
+                    CreatedAt = DateTimeOffset.UtcNow
+                });
+            }
+        }
+
+        var orderedNotifications = notifications
+            .OrderByDescending(n => n.CreatedAt ?? DateTimeOffset.MinValue)
+            .Take(10)
+            .ToList();
+
         return new HrDashboardViewModel
         {
             OrganizationName = org?.Name ?? "Organization",
             Invite = invite,
             PendingLeaveRequests = pendingViewModels,
-            LeaveSummaries = leaveSummaries
+            LeaveSummaries = leaveSummaries,
+            Notifications = orderedNotifications
         };
     }
 

--- a/Models/HrDashboardViewModel.cs
+++ b/Models/HrDashboardViewModel.cs
@@ -6,6 +6,7 @@ public sealed class HrDashboardViewModel
     public InviteEmployeeViewModel Invite { get; init; } = new();
     public IReadOnlyList<LeaveRequestReviewViewModel> PendingLeaveRequests { get; init; } = Array.Empty<LeaveRequestReviewViewModel>();
     public IReadOnlyList<LeaveBalanceSummaryViewModel> LeaveSummaries { get; init; } = Array.Empty<LeaveBalanceSummaryViewModel>();
+    public IReadOnlyList<DashboardNotificationViewModel> Notifications { get; init; } = Array.Empty<DashboardNotificationViewModel>();
 }
 
 public sealed class LeaveRequestReviewViewModel
@@ -28,5 +29,13 @@ public sealed class LeaveBalanceSummaryViewModel
     public required int UsedDays { get; init; }
     public required int PendingDays { get; init; }
     public int AvailableDays => Math.Max(0, AnnualEntitlement - UsedDays - PendingDays);
+}
+
+public sealed class DashboardNotificationViewModel
+{
+    public required string Title { get; init; }
+    public required string Message { get; init; }
+    public required string Category { get; init; }
+    public DateTimeOffset? CreatedAt { get; init; }
 }
 

--- a/Views/HrDashboard/Index.cshtml
+++ b/Views/HrDashboard/Index.cshtml
@@ -142,6 +142,43 @@
     <div class="col-12 col-xl-4">
         <div class="card shadow-sm mb-4">
             <div class="card-body p-4">
+                <h2 class="h6 mb-3">Notifications &amp; reminders</h2>
+                @if (Model.Notifications.Count == 0)
+                {
+                    <p class="text-secondary mb-0">You're all caught up. No new alerts.</p>
+                }
+                else
+                {
+                    <div class="list-group list-group-flush">
+                        @foreach (var notification in Model.Notifications)
+                        {
+                            @{ var badgeClass = notification.Category switch
+                               {
+                                   "Leave" => "bg-primary",
+                                   "Attendance" => "bg-warning text-dark",
+                                   "Reports" => "bg-success",
+                                   _ => "bg-secondary"
+                               }; }
+                            <div class="list-group-item px-0">
+                                <div class="d-flex justify-content-between align-items-start">
+                                    <div>
+                                        <div class="fw-semibold">@notification.Title</div>
+                                        <div class="text-secondary small">@notification.Message</div>
+                                    </div>
+                                    <span class="badge rounded-pill @badgeClass">@notification.Category</span>
+                                </div>
+                                @if (notification.CreatedAt is DateTimeOffset timestamp)
+                                {
+                                    <div class="text-muted small mt-2">Updated @timestamp.ToLocalTime():g</div>
+                                }
+                            </div>
+                        }
+                    </div>
+                }
+            </div>
+        </div>
+        <div class="card shadow-sm mb-4">
+            <div class="card-body p-4">
                 <h2 class="h6 mb-3">Leave entitlements</h2>
                 @if (Model.LeaveSummaries.Count == 0)
                 {


### PR DESCRIPTION
## Summary
- add notification view model entries for HR dashboard data
- gather pending leave, late arrivals, and monthly attendance summaries for notifications
- surface notifications and reminders on the HR dashboard sidebar

## Testing
- `dotnet build` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca40f7bdf88328937dbfda44018fc6