### PR TITLE
Simplify notification badge class assignment

### DIFF
--- a/Views/HrDashboard/Index.cshtml
+++ b/Views/HrDashboard/Index.cshtml
@@ -152,13 +152,13 @@
                     <div class="list-group list-group-flush">
                         @foreach (var notification in Model.Notifications)
                         {
-                            @{ var badgeClass = notification.Category switch
-                               {
-                                   "Leave" => "bg-primary",
-                                   "Attendance" => "bg-warning text-dark",
-                                   "Reports" => "bg-success",
-                                   _ => "bg-secondary"
-                               }; }
+                            var badgeClass = notification.Category switch
+                            {
+                                "Leave" => "bg-primary",
+                                "Attendance" => "bg-warning text-dark",
+                                "Reports" => "bg-success",
+                                _ => "bg-secondary"
+                            };
                             <div class="list-group-item px-0">
                                 <div class="d-flex justify-content-between align-items-start">
                                     <div>


### PR DESCRIPTION
## Summary
- remove the inline code block wrapper when assigning the notification badge class so the declaration sits directly in the foreach loop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca44d2c85c8328ac6df5a01472f0da