### PR TITLE
Add sidebar icons and improve collapsed navigation

### DIFF
--- a/Views/Shared/_Layout.App.cshtml
+++ b/Views/Shared/_Layout.App.cshtml
@@ -11,6 +11,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>@title</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
     <link href="~/css/site.css" rel="stylesheet" />
     @RenderSection("HeadContent", required: false)
 </head>
@@ -25,25 +26,58 @@
 
                 @if (isIT)
                 {
-                    <a class="nav-link" asp-controller="Dashboard" asp-action="Index">IT Dashboard</a>
+                    <a class="nav-link d-flex align-items-center" asp-controller="Dashboard" asp-action="Index" title="IT Dashboard" aria-label="IT Dashboard">
+                        <i class="bi bi-speedometer2 nav-link-icon" aria-hidden="true"></i>
+                        <span class="nav-link-label">IT Dashboard</span>
+                    </a>
                     <div class="px-3 text-uppercase small text-secondary mt-3 mb-1">Admin</div>
-                    <a class="nav-link" href="#">Organization</a>
-                    <a class="nav-link" asp-controller="Dashboard" asp-action="People">People</a>
-                    <a class="nav-link" href="#">Settings</a>
-                    <a class="nav-link" asp-controller="Profile" asp-action="Index">My profile</a>
+                    <a class="nav-link d-flex align-items-center" href="#" title="Organization" aria-label="Organization">
+                        <i class="bi bi-diagram-3 nav-link-icon" aria-hidden="true"></i>
+                        <span class="nav-link-label">Organization</span>
+                    </a>
+                    <a class="nav-link d-flex align-items-center" asp-controller="Dashboard" asp-action="People" title="People" aria-label="People">
+                        <i class="bi bi-people nav-link-icon" aria-hidden="true"></i>
+                        <span class="nav-link-label">People</span>
+                    </a>
+                    <a class="nav-link d-flex align-items-center" href="#" title="Settings" aria-label="Settings">
+                        <i class="bi bi-gear nav-link-icon" aria-hidden="true"></i>
+                        <span class="nav-link-label">Settings</span>
+                    </a>
+                    <a class="nav-link d-flex align-items-center" asp-controller="Profile" asp-action="Index" title="My profile" aria-label="My profile">
+                        <i class="bi bi-person-circle nav-link-icon" aria-hidden="true"></i>
+                        <span class="nav-link-label">My profile</span>
+                    </a>
                 }
                 else if (isHR)
                 {
-                    <a class="nav-link" asp-controller="HrDashboard" asp-action="Index">HR Dashboard</a>
+                    <a class="nav-link d-flex align-items-center" asp-controller="HrDashboard" asp-action="Index" title="HR Dashboard" aria-label="HR Dashboard">
+                        <i class="bi bi-graph-up nav-link-icon" aria-hidden="true"></i>
+                        <span class="nav-link-label">HR Dashboard</span>
+                    </a>
                     <div class="px-3 text-uppercase small text-secondary mt-3 mb-1">Admin</div>
-                    <a class="nav-link" asp-controller="Dashboard" asp-action="People">People</a>
-                    <a class="nav-link" asp-controller="Payroll" asp-action="Index">Payroll</a>
-                    <a class="nav-link" asp-controller="Profile" asp-action="Index">My profile</a>
+                    <a class="nav-link d-flex align-items-center" asp-controller="Dashboard" asp-action="People" title="People" aria-label="People">
+                        <i class="bi bi-people nav-link-icon" aria-hidden="true"></i>
+                        <span class="nav-link-label">People</span>
+                    </a>
+                    <a class="nav-link d-flex align-items-center" asp-controller="Payroll" asp-action="Index" title="Payroll" aria-label="Payroll">
+                        <i class="bi bi-cash-stack nav-link-icon" aria-hidden="true"></i>
+                        <span class="nav-link-label">Payroll</span>
+                    </a>
+                    <a class="nav-link d-flex align-items-center" asp-controller="Profile" asp-action="Index" title="My profile" aria-label="My profile">
+                        <i class="bi bi-person-circle nav-link-icon" aria-hidden="true"></i>
+                        <span class="nav-link-label">My profile</span>
+                    </a>
                 }
                 else if (isEmployee)
                 {
-                    <a class="nav-link" asp-controller="EmployeeDashboard" asp-action="Index">Employee Dashboard</a>
-                    <a class="nav-link" asp-controller="Profile" asp-action="Index">My profile</a>
+                    <a class="nav-link d-flex align-items-center" asp-controller="EmployeeDashboard" asp-action="Index" title="Employee Dashboard" aria-label="Employee Dashboard">
+                        <i class="bi bi-speedometer2 nav-link-icon" aria-hidden="true"></i>
+                        <span class="nav-link-label">Employee Dashboard</span>
+                    </a>
+                    <a class="nav-link d-flex align-items-center" asp-controller="Profile" asp-action="Index" title="My profile" aria-label="My profile">
+                        <i class="bi bi-person-circle nav-link-icon" aria-hidden="true"></i>
+                        <span class="nav-link-label">My profile</span>
+                    </a>
                 }
             </nav>
         </aside>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -20,28 +20,52 @@ body {
 .app-shell .nav-link {
     color: #333;
     padding: 0.6rem 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    transition: background-color 0.2s ease;
 }
 
-    .app-shell .nav-link:hover {
-        background: #f1f5f9;
-    }
+.app-shell .nav-link:hover {
+    background: #f1f5f9;
+}
+
+.app-shell .nav-link-icon {
+    font-size: 1.1rem;
+    width: 1.5rem;
+    text-align: center;
+    flex-shrink: 0;
+    color: inherit;
+}
+
+.app-shell .nav-link-label {
+    flex: 1;
+    white-space: nowrap;
+}
 
 #app-shell.sidebar-collapsed .sidebar {
     width: 72px;
 }
 
-    #app-shell.sidebar-collapsed .sidebar .nav-link {
-        text-indent: 0;
-    }
+#app-shell.sidebar-collapsed .sidebar .nav-link {
+    justify-content: center;
+    padding-left: 0;
+    padding-right: 0;
+}
 
-    #app-shell.sidebar-collapsed .sidebar .sidebar-brand a {
-        font-size: 0;
-    }
+#app-shell.sidebar-collapsed .sidebar .nav-link-label,
+#app-shell.sidebar-collapsed .sidebar .text-uppercase {
+    display: none;
+}
 
-        #app-shell.sidebar-collapsed .sidebar .sidebar-brand a::after {
-            content: "TH";
-            font-size: 1rem;
-        }
+#app-shell.sidebar-collapsed .sidebar .sidebar-brand a {
+    font-size: 0;
+}
+
+#app-shell.sidebar-collapsed .sidebar .sidebar-brand a::after {
+    content: "TH";
+    font-size: 1rem;
+}
 
 /* Optional: card rounding and subtle shadow */
 .card {


### PR DESCRIPTION
## Summary
- render Bootstrap icons beside each dashboard navigation link in the app layout and provide accessible labels
- refine the sidebar styles so labels collapse cleanly, hiding section headers when the shell is collapsed

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca54f4980883288c1ee219de0bea5c