### PR TITLE
Add super admin user management

### DIFF
--- a/Controllers/UsersController.cs
+++ b/Controllers/UsersController.cs
@@ -1,12 +1,480 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using TrackHive.Models;
 
-namespace TrackHive.Controllers
+namespace TrackHive.Controllers;
+
+[Authorize(Roles = "IT")]
+public sealed class UsersController : Controller
 {
-    public class UsersController : Controller
+    private readonly AppDbContext _db;
+
+    public UsersController(AppDbContext db)
     {
-        public IActionResult Index()
+        _db = db;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Index(
+        string? q = null,
+        int? orgId = null,
+        RoleType? role = null,
+        string? status = null,
+        string? sortBy = "created",
+        string? sortDir = "desc",
+        int page = 1,
+        int pageSize = 15)
+    {
+        page = page < 1 ? 1 : page;
+        pageSize = pageSize is < 5 or > 100 ? 15 : pageSize;
+
+        status = (status ?? "any").ToLowerInvariant();
+        if (status is not ("any" or "active" or "inactive" or "locked" or "mustchangepassword"))
+            status = "any";
+
+        sortBy = (sortBy ?? "created").ToLowerInvariant();
+        if (sortBy is not ("name" or "email" or "org" or "role" or "created" or "status"))
+            sortBy = "created";
+
+        sortDir = (sortDir ?? "desc").ToLowerInvariant();
+        if (sortDir is not ("asc" or "desc"))
+            sortDir = "desc";
+
+        IQueryable<AppUser> query = _db.Users
+            .Include(u => u.Organization)
+            .AsNoTracking();
+
+        if (!string.IsNullOrWhiteSpace(q))
         {
-            return View();
+            var pattern = $"%{q.Trim()}%";
+            query = query.Where(u => EF.Functions.Like(u.Name, pattern) || EF.Functions.Like(u.Email, pattern));
         }
+
+        if (orgId.HasValue && orgId.Value > 0)
+        {
+            query = query.Where(u => u.OrganizationId == orgId.Value);
+        }
+
+        if (role.HasValue)
+        {
+            query = query.Where(u => u.Role == role.Value);
+        }
+
+        query = status switch
+        {
+            "active" => query.Where(u => u.IsActive),
+            "inactive" => query.Where(u => !u.IsActive),
+            "locked" => query.Where(u => u.IsLocked),
+            "mustchangepassword" => query.Where(u => u.MustChangePassword),
+            _ => query
+        };
+
+        query = (sortBy, sortDir) switch
+        {
+            ("name", "asc") => query.OrderBy(u => u.Name).ThenBy(u => u.Id),
+            ("name", _) => query.OrderByDescending(u => u.Name).ThenByDescending(u => u.Id),
+            ("email", "asc") => query.OrderBy(u => u.Email).ThenBy(u => u.Id),
+            ("email", _) => query.OrderByDescending(u => u.Email).ThenByDescending(u => u.Id),
+            ("org", "asc") => query.OrderBy(u => u.Organization!.Name).ThenBy(u => u.Id),
+            ("org", _) => query.OrderByDescending(u => u.Organization!.Name).ThenByDescending(u => u.Id),
+            ("role", "asc") => query.OrderBy(u => u.Role).ThenBy(u => u.Id),
+            ("role", _) => query.OrderByDescending(u => u.Role).ThenByDescending(u => u.Id),
+            ("status", "asc") => query.OrderBy(u => u.IsActive).ThenBy(u => u.Id),
+            ("status", _) => query.OrderByDescending(u => u.IsActive).ThenByDescending(u => u.Id),
+            ("created", "asc") => query.OrderBy(u => u.CreatedAt).ThenBy(u => u.Id),
+            _ => query.OrderByDescending(u => u.CreatedAt).ThenByDescending(u => u.Id)
+        };
+
+        var total = await query.CountAsync();
+        var items = await query
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync();
+
+        var rows = items.Select(u => new AdminUserRow
+        {
+            Id = u.Id,
+            Name = u.Name,
+            Email = u.Email,
+            Organization = u.Organization?.Name ?? "—",
+            Role = u.Role,
+            IsActive = u.IsActive,
+            IsLocked = u.IsLocked,
+            MustChangePassword = u.MustChangePassword,
+            CreatedAt = u.CreatedAt
+        }).ToList();
+
+        var organizations = await _db.Organizations
+            .OrderBy(o => o.Name)
+            .Select(o => new OrganizationOption
+            {
+                Id = o.Id,
+                Name = o.Name
+            })
+            .ToListAsync();
+
+        var vm = new AdminUsersIndexViewModel
+        {
+            Users = rows,
+            Organizations = organizations,
+            Query = q,
+            OrganizationId = orgId > 0 ? orgId : null,
+            Role = role,
+            Status = status,
+            SortBy = sortBy,
+            SortDir = sortDir,
+            Page = page,
+            PageSize = pageSize,
+            TotalCount = total
+        };
+
+        return View(vm);
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Create()
+    {
+        var model = new AdminUserFormViewModel
+        {
+            IsActive = true,
+            MustChangePassword = true
+        };
+        await PopulateOrganizationsAsync(model);
+        return View(model);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Create(AdminUserFormViewModel model)
+    {
+        if (string.IsNullOrWhiteSpace(model.Password) || model.Password.Length < 8)
+        {
+            ModelState.AddModelError(nameof(AdminUserFormViewModel.Password), "Password must be at least 8 characters.");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            await PopulateOrganizationsAsync(model);
+            return View(model);
+        }
+
+        var emailLower = model.Email.Trim().ToLowerInvariant();
+        var exists = await _db.Users.AnyAsync(u => u.Email.ToLower() == emailLower);
+        if (exists)
+        {
+            ModelState.AddModelError(nameof(AdminUserFormViewModel.Email), "Email is already in use.");
+            await PopulateOrganizationsAsync(model);
+            return View(model);
+        }
+
+        var org = await _db.Organizations.FindAsync(model.OrganizationId);
+        if (org is null)
+        {
+            ModelState.AddModelError(nameof(AdminUserFormViewModel.OrganizationId), "Organization not found.");
+            await PopulateOrganizationsAsync(model);
+            return View(model);
+        }
+
+        var user = new AppUser
+        {
+            Name = model.Name.Trim(),
+            Email = model.Email.Trim(),
+            Role = model.Role,
+            OrganizationId = org.Id,
+            IsActive = model.IsActive,
+            MustChangePassword = model.MustChangePassword,
+            PasswordHash = PasswordHasher.Hash(model.Password!.Trim())
+        };
+
+        _db.Users.Add(user);
+        await _db.SaveChangesAsync();
+
+        TempData["Toast"] = $"Created user '{user.Name}'.";
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Edit(int id)
+    {
+        var user = await _db.Users.FirstOrDefaultAsync(u => u.Id == id);
+        if (user is null) return NotFound();
+
+        var model = new AdminUserFormViewModel
+        {
+            Id = user.Id,
+            Name = user.Name,
+            Email = user.Email,
+            Role = user.Role,
+            OrganizationId = user.OrganizationId,
+            IsActive = user.IsActive,
+            MustChangePassword = user.MustChangePassword
+        };
+        await PopulateOrganizationsAsync(model);
+        return View(model);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Edit(AdminUserFormViewModel model)
+    {
+        if (model.Id is null)
+        {
+            return NotFound();
+        }
+
+        if (!string.IsNullOrWhiteSpace(model.Password) && model.Password.Length < 8)
+        {
+            ModelState.AddModelError(nameof(AdminUserFormViewModel.Password), "Password must be at least 8 characters.");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            await PopulateOrganizationsAsync(model);
+            return View(model);
+        }
+
+        var user = await _db.Users.FirstOrDefaultAsync(u => u.Id == model.Id);
+        if (user is null) return NotFound();
+
+        var emailLower = model.Email.Trim().ToLowerInvariant();
+        var emailInUse = await _db.Users
+            .AnyAsync(u => u.Email.ToLower() == emailLower && u.Id != user.Id);
+        if (emailInUse)
+        {
+            ModelState.AddModelError(nameof(AdminUserFormViewModel.Email), "Email is already in use.");
+            await PopulateOrganizationsAsync(model);
+            return View(model);
+        }
+
+        var org = await _db.Organizations.FindAsync(model.OrganizationId);
+        if (org is null)
+        {
+            ModelState.AddModelError(nameof(AdminUserFormViewModel.OrganizationId), "Organization not found.");
+            await PopulateOrganizationsAsync(model);
+            return View(model);
+        }
+
+        user.Name = model.Name.Trim();
+        user.Email = model.Email.Trim();
+        user.Role = model.Role;
+        user.OrganizationId = org.Id;
+        user.IsActive = model.IsActive;
+        user.MustChangePassword = model.MustChangePassword;
+        if (!string.IsNullOrWhiteSpace(model.Password))
+        {
+            user.PasswordHash = PasswordHasher.Hash(model.Password.Trim());
+            user.MustChangePassword = true;
+        }
+
+        await _db.SaveChangesAsync();
+
+        TempData["Toast"] = "User updated.";
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> ToggleActive(
+        int id,
+        string? q,
+        int? orgId,
+        RoleType? role,
+        string? status,
+        string? sortBy,
+        string? sortDir,
+        int page = 1,
+        int pageSize = 15)
+    {
+        var user = await _db.Users.FirstOrDefaultAsync(u => u.Id == id);
+        if (user is null)
+        {
+            TempData["Error"] = "User not found.";
+            return RedirectToIndex(q, orgId, role, status, sortBy, sortDir, page, pageSize);
+        }
+
+        var meId = GetCurrentUserId();
+        if (meId.HasValue && user.Id == meId.Value)
+        {
+            TempData["Error"] = "You cannot change your own activation status.";
+            return RedirectToIndex(q, orgId, role, status, sortBy, sortDir, page, pageSize);
+        }
+
+        user.IsActive = !user.IsActive;
+        await _db.SaveChangesAsync();
+
+        TempData["Toast"] = user.IsActive ? "Account activated." : "Account deactivated.";
+        return RedirectToIndex(q, orgId, role, status, sortBy, sortDir, page, pageSize);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Delete(
+        int id,
+        string? q,
+        int? orgId,
+        RoleType? role,
+        string? status,
+        string? sortBy,
+        string? sortDir,
+        int page = 1,
+        int pageSize = 15)
+    {
+        var user = await _db.Users.FirstOrDefaultAsync(u => u.Id == id);
+        if (user is null)
+        {
+            TempData["Error"] = "User not found.";
+            return RedirectToIndex(q, orgId, role, status, sortBy, sortDir, page, pageSize);
+        }
+
+        var meId = GetCurrentUserId();
+        if (meId.HasValue && user.Id == meId.Value)
+        {
+            TempData["Error"] = "You cannot delete your own account.";
+            return RedirectToIndex(q, orgId, role, status, sortBy, sortDir, page, pageSize);
+        }
+
+        _db.Users.Remove(user);
+        await _db.SaveChangesAsync();
+
+        TempData["Toast"] = "User deleted.";
+        return RedirectToIndex(q, orgId, role, status, sortBy, sortDir, page, pageSize);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Bulk(
+        string cmd,
+        int[] ids,
+        string? q,
+        int? orgId,
+        RoleType? role,
+        string? status,
+        string? sortBy,
+        string? sortDir,
+        int page = 1,
+        int pageSize = 15)
+    {
+        if (ids is null || ids.Length == 0)
+        {
+            TempData["Error"] = "No users selected.";
+            return RedirectToIndex(q, orgId, role, status, sortBy, sortDir, page, pageSize);
+        }
+
+        cmd = (cmd ?? string.Empty).ToLowerInvariant();
+        if (cmd is not ("activate" or "deactivate" or "delete"))
+        {
+            TempData["Error"] = "Unknown bulk action.";
+            return RedirectToIndex(q, orgId, role, status, sortBy, sortDir, page, pageSize);
+        }
+
+        var meId = GetCurrentUserId();
+        var users = await _db.Users.Where(u => ids.Contains(u.Id)).ToListAsync();
+
+        int skipped = 0;
+        if (cmd == "delete")
+        {
+            var toRemove = new List<AppUser>();
+            foreach (var u in users)
+            {
+                if (meId.HasValue && u.Id == meId.Value)
+                {
+                    skipped++;
+                    continue;
+                }
+                toRemove.Add(u);
+            }
+
+            if (toRemove.Count > 0)
+            {
+                _db.Users.RemoveRange(toRemove);
+                await _db.SaveChangesAsync();
+                TempData["Toast"] = $"Deleted {toRemove.Count} user(s)." + (skipped > 0 ? $" Skipped {skipped}." : string.Empty);
+            }
+            else
+            {
+                TempData["Error"] = skipped > 0 ? "Cannot delete your own account." : "No users deleted.";
+            }
+        }
+        else
+        {
+            bool newState = cmd == "activate";
+            int changed = 0;
+            foreach (var u in users)
+            {
+                if (meId.HasValue && u.Id == meId.Value)
+                {
+                    skipped++;
+                    continue;
+                }
+
+                if (u.IsActive != newState)
+                {
+                    u.IsActive = newState;
+                    changed++;
+                }
+            }
+
+            if (changed > 0)
+            {
+                await _db.SaveChangesAsync();
+                TempData["Toast"] = $"{(newState ? "Activated" : "Deactivated")} {changed} user(s)." +
+                                    (skipped > 0 ? $" Skipped {skipped}." : string.Empty);
+            }
+            else
+            {
+                TempData["Error"] = skipped > 0 ? "Cannot change your own account state." : "No changes were required.";
+            }
+        }
+
+        return RedirectToIndex(q, orgId, role, status, sortBy, sortDir, page, pageSize);
+    }
+
+    private async Task PopulateOrganizationsAsync(AdminUserFormViewModel model)
+    {
+        var items = await _db.Organizations
+            .OrderBy(o => o.Name)
+            .Select(o => new SelectListItem
+            {
+                Value = o.Id.ToString(),
+                Text = o.Name
+            })
+            .ToListAsync();
+
+        model.Organizations = items;
+    }
+
+    private RedirectToActionResult RedirectToIndex(
+        string? q,
+        int? orgId,
+        RoleType? role,
+        string? status,
+        string? sortBy,
+        string? sortDir,
+        int page,
+        int pageSize)
+    {
+        return RedirectToAction(nameof(Index), new
+        {
+            q,
+            orgId = orgId.HasValue && orgId.Value > 0 ? orgId : null,
+            role = role.HasValue ? (int?)role.Value : null,
+            status,
+            sortBy,
+            sortDir,
+            page,
+            pageSize
+        });
+    }
+
+    private int? GetCurrentUserId()
+    {
+        var idStr = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (int.TryParse(idStr, out var id)) return id;
+        return null;
     }
 }

--- a/Models/AdminUserFormViewModel.cs
+++ b/Models/AdminUserFormViewModel.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace TrackHive.Models;
+
+public sealed class AdminUserFormViewModel
+{
+    public int? Id { get; set; }
+
+    [Required, StringLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required, EmailAddress, StringLength(256)]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    public RoleType Role { get; set; } = RoleType.Employee;
+
+    [Display(Name = "Organization")]
+    [Required(ErrorMessage = "Please choose an organization.")]
+    public int OrganizationId { get; set; }
+
+    [Display(Name = "Active")]
+    public bool IsActive { get; set; } = true;
+
+    [Display(Name = "Must change password on next sign-in")]
+    public bool MustChangePassword { get; set; }
+
+    [DataType(DataType.Password)]
+    public string? Password { get; set; }
+
+    [DataType(DataType.Password)]
+    [Display(Name = "Confirm password")]
+    [Compare(nameof(Password), ErrorMessage = "The password confirmation does not match.")]
+    public string? ConfirmPassword { get; set; }
+
+    public List<SelectListItem> Organizations { get; set; } = new();
+}

--- a/Models/AdminUsersIndexViewModel.cs
+++ b/Models/AdminUsersIndexViewModel.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+
+namespace TrackHive.Models;
+
+public sealed class AdminUsersIndexViewModel
+{
+    public List<AdminUserRow> Users { get; set; } = new();
+    public List<OrganizationOption> Organizations { get; set; } = new();
+    public string? Query { get; set; }
+    public int? OrganizationId { get; set; }
+    public RoleType? Role { get; set; }
+    public string Status { get; set; } = "any";
+    public string SortBy { get; set; } = "created";
+    public string SortDir { get; set; } = "desc";
+    public int Page { get; set; } = 1;
+    public int PageSize { get; set; } = 15;
+    public int TotalCount { get; set; }
+}
+
+public sealed class AdminUserRow
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string Organization { get; set; } = string.Empty;
+    public RoleType Role { get; set; }
+    public bool IsActive { get; set; }
+    public bool IsLocked { get; set; }
+    public bool MustChangePassword { get; set; }
+    public DateTime CreatedAt { get; set; }
+}
+
+public sealed class OrganizationOption
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}

--- a/Views/Shared/_Layout.App.cshtml
+++ b/Views/Shared/_Layout.App.cshtml
@@ -31,9 +31,9 @@
                         <span class="nav-link-label">IT Dashboard</span>
                     </a>
                     <div class="px-3 text-uppercase small text-secondary mt-3 mb-1">Admin</div>
-                    <a class="nav-link d-flex align-items-center" href="#" title="Organization" aria-label="Organization">
+                    <a class="nav-link d-flex align-items-center" asp-controller="Users" asp-action="Index" title="All users" aria-label="All users">
                         <i class="bi bi-diagram-3 nav-link-icon" aria-hidden="true"></i>
-                        <span class="nav-link-label">Organization</span>
+                        <span class="nav-link-label">All users</span>
                     </a>
                     <a class="nav-link d-flex align-items-center" asp-controller="Dashboard" asp-action="People" title="People" aria-label="People">
                         <i class="bi bi-people nav-link-icon" aria-hidden="true"></i>

--- a/Views/Users/Create.cshtml
+++ b/Views/Users/Create.cshtml
@@ -1,0 +1,82 @@
+@model TrackHive.Models.AdminUserFormViewModel
+@{
+    Layout = "_Layout.App";
+    ViewData["Title"] = "Create user";
+}
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="h4 mb-0">Create user</h1>
+    <a class="btn btn-outline-secondary" asp-action="Index">Back to list</a>
+</div>
+
+<div class="card shadow-sm">
+    <div class="card-body">
+        <form asp-action="Create" method="post" class="row g-3">
+            @Html.AntiForgeryToken()
+
+            <div class="col-md-6">
+                <label asp-for="Name" class="form-label"></label>
+                <input asp-for="Name" class="form-control" />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+
+            <div class="col-md-6">
+                <label asp-for="Email" class="form-label"></label>
+                <input asp-for="Email" class="form-control" />
+                <span asp-validation-for="Email" class="text-danger"></span>
+            </div>
+
+            <div class="col-md-6">
+                <label asp-for="Role" class="form-label"></label>
+                <select asp-for="Role" class="form-select" asp-items="Html.GetEnumSelectList<RoleType>()"></select>
+                <span asp-validation-for="Role" class="text-danger"></span>
+            </div>
+
+            <div class="col-md-6">
+                <label asp-for="OrganizationId" class="form-label"></label>
+                <select asp-for="OrganizationId" class="form-select" asp-items="Model.Organizations">
+                    <option value="">Select organization</option>
+                </select>
+                <span asp-validation-for="OrganizationId" class="text-danger"></span>
+            </div>
+
+            <div class="col-md-6">
+                <label asp-for="Password" class="form-label"></label>
+                <input asp-for="Password" class="form-control" autocomplete="new-password" />
+                <span asp-validation-for="Password" class="text-danger"></span>
+                <div class="form-text">Password must be at least 8 characters.</div>
+            </div>
+
+            <div class="col-md-6">
+                <label asp-for="ConfirmPassword" class="form-label"></label>
+                <input asp-for="ConfirmPassword" class="form-control" autocomplete="new-password" />
+                <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
+            </div>
+
+            <div class="col-12">
+                <div class="form-check form-switch">
+                    <input class="form-check-input" asp-for="IsActive" />
+                    <label class="form-check-label" asp-for="IsActive"></label>
+                </div>
+            </div>
+
+            <div class="col-12">
+                <div class="form-check form-switch">
+                    <input class="form-check-input" asp-for="MustChangePassword" />
+                    <label class="form-check-label" asp-for="MustChangePassword"></label>
+                </div>
+            </div>
+
+            <div class="col-12 d-flex gap-2">
+                <button type="submit" class="btn btn-primary">Create</button>
+                <a class="btn btn-outline-secondary" asp-action="Index">Cancel</a>
+            </div>
+        </form>
+    </div>
+</div>
+
+@section Scripts {
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.19.5/jquery.validate.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate-unobtrusive/3.2.12/jquery.validate.unobtrusive.min.js" crossorigin="anonymous"></script>
+}

--- a/Views/Users/Edit.cshtml
+++ b/Views/Users/Edit.cshtml
@@ -1,0 +1,83 @@
+@model TrackHive.Models.AdminUserFormViewModel
+@{
+    Layout = "_Layout.App";
+    ViewData["Title"] = "Edit user";
+}
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="h4 mb-0">Edit user</h1>
+    <a class="btn btn-outline-secondary" asp-action="Index">Back to list</a>
+</div>
+
+<div class="card shadow-sm">
+    <div class="card-body">
+        <form asp-action="Edit" method="post" class="row g-3">
+            @Html.AntiForgeryToken()
+            <input type="hidden" asp-for="Id" />
+
+            <div class="col-md-6">
+                <label asp-for="Name" class="form-label"></label>
+                <input asp-for="Name" class="form-control" />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+
+            <div class="col-md-6">
+                <label asp-for="Email" class="form-label"></label>
+                <input asp-for="Email" class="form-control" />
+                <span asp-validation-for="Email" class="text-danger"></span>
+            </div>
+
+            <div class="col-md-6">
+                <label asp-for="Role" class="form-label"></label>
+                <select asp-for="Role" class="form-select" asp-items="Html.GetEnumSelectList<RoleType>()"></select>
+                <span asp-validation-for="Role" class="text-danger"></span>
+            </div>
+
+            <div class="col-md-6">
+                <label asp-for="OrganizationId" class="form-label"></label>
+                <select asp-for="OrganizationId" class="form-select" asp-items="Model.Organizations">
+                    <option value="">Select organization</option>
+                </select>
+                <span asp-validation-for="OrganizationId" class="text-danger"></span>
+            </div>
+
+            <div class="col-md-6">
+                <label asp-for="Password" class="form-label">New password</label>
+                <input asp-for="Password" class="form-control" autocomplete="new-password" />
+                <span asp-validation-for="Password" class="text-danger"></span>
+                <div class="form-text">Leave blank to keep the current password. Minimum 8 characters.</div>
+            </div>
+
+            <div class="col-md-6">
+                <label asp-for="ConfirmPassword" class="form-label"></label>
+                <input asp-for="ConfirmPassword" class="form-control" autocomplete="new-password" />
+                <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
+            </div>
+
+            <div class="col-12">
+                <div class="form-check form-switch">
+                    <input class="form-check-input" asp-for="IsActive" />
+                    <label class="form-check-label" asp-for="IsActive"></label>
+                </div>
+            </div>
+
+            <div class="col-12">
+                <div class="form-check form-switch">
+                    <input class="form-check-input" asp-for="MustChangePassword" />
+                    <label class="form-check-label" asp-for="MustChangePassword"></label>
+                </div>
+            </div>
+
+            <div class="col-12 d-flex gap-2">
+                <button type="submit" class="btn btn-primary">Save changes</button>
+                <a class="btn btn-outline-secondary" asp-action="Index">Cancel</a>
+            </div>
+        </form>
+    </div>
+</div>
+
+@section Scripts {
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.19.5/jquery.validate.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate-unobtrusive/3.2.12/jquery.validate.unobtrusive.min.js" crossorigin="anonymous"></script>
+}

--- a/Views/Users/Index.cshtml
+++ b/Views/Users/Index.cshtml
@@ -1,0 +1,369 @@
+@model TrackHive.Models.AdminUsersIndexViewModel
+@{
+    Layout = "_Layout.App";
+    ViewData["Title"] = "All users";
+
+    var orgValue = Model.OrganizationId.HasValue ? Model.OrganizationId.Value.ToString() : string.Empty;
+    var roleValue = Model.Role.HasValue ? ((int)Model.Role.Value).ToString() : string.Empty;
+    var statusValue = string.IsNullOrWhiteSpace(Model.Status) ? "any" : Model.Status;
+    int start = Model.TotalCount == 0 ? 0 : ((Model.Page - 1) * Model.PageSize) + 1;
+    int end = Math.Min(Model.Page * Model.PageSize, Model.TotalCount);
+    int totalPages = (int)Math.Ceiling(Model.TotalCount / (double)Model.PageSize);
+}
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <div>
+        <h1 class="h4 mb-1">All users</h1>
+        <div class="small text-secondary">Showing @start–@end of @Model.TotalCount</div>
+    </div>
+    <a class="btn btn-primary" asp-action="Create">Create user</a>
+</div>
+
+@if (TempData["Toast"] is string toast)
+{
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        @toast
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+}
+@if (TempData["Error"] is string err)
+{
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+        @err
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+}
+
+<form method="get" class="row g-2 align-items-end mb-4">
+    <input type="hidden" name="sortBy" value="@Model.SortBy" />
+    <input type="hidden" name="sortDir" value="@Model.SortDir" />
+    <input type="hidden" name="page" value="1" />
+
+    <div class="col-12 col-md-4 col-xl-3">
+        <label class="form-label" for="filterSearch">Search</label>
+        <input id="filterSearch" name="q" class="form-control" type="search" placeholder="Name or email"
+               value="@Model.Query" />
+    </div>
+    <div class="col-12 col-md-3 col-xl-3">
+        <label class="form-label" for="filterOrg">Organization</label>
+        <select id="filterOrg" name="orgId" class="form-select">
+            <option value="">All organizations</option>
+            @foreach (var org in Model.Organizations)
+            {
+                <option value="@org.Id" selected="@(orgValue == org.Id.ToString() ? "selected" : null)">@org.Name</option>
+            }
+        </select>
+    </div>
+    <div class="col-12 col-md-2 col-xl-2">
+        <label class="form-label" for="filterRole">Role</label>
+        <select id="filterRole" name="role" class="form-select">
+            <option value="">All roles</option>
+            <option value="1" selected="@(roleValue == "1" ? "selected" : null)">IT</option>
+            <option value="2" selected="@(roleValue == "2" ? "selected" : null)">HR</option>
+            <option value="3" selected="@(roleValue == "3" ? "selected" : null)">Employee</option>
+        </select>
+    </div>
+    <div class="col-12 col-md-3 col-xl-2">
+        <label class="form-label" for="filterStatus">Status</label>
+        <select id="filterStatus" name="status" class="form-select">
+            <option value="any" selected="@(statusValue == "any" ? "selected" : null)">Any status</option>
+            <option value="active" selected="@(statusValue == "active" ? "selected" : null)">Active</option>
+            <option value="inactive" selected="@(statusValue == "inactive" ? "selected" : null)">Inactive</option>
+            <option value="locked" selected="@(statusValue == "locked" ? "selected" : null)">Locked</option>
+            <option value="mustchangepassword" selected="@(statusValue == "mustchangepassword" ? "selected" : null)">Must change password</option>
+        </select>
+    </div>
+    <div class="col-12 col-md-2 col-xl-1">
+        <label class="form-label" for="filterPageSize">Page size</label>
+        <select id="filterPageSize" name="pageSize" class="form-select">
+            @foreach (var size in new[] { 10, 15, 25, 50, 100 })
+            {
+                <option value="@size" selected="@(Model.PageSize == size ? "selected" : null)">@size</option>
+            }
+        </select>
+    </div>
+    <div class="col-12 col-md-2 col-xl-1 d-flex gap-2">
+        <button type="submit" class="btn btn-outline-primary flex-grow-1">Apply</button>
+        <a class="btn btn-outline-secondary flex-grow-1" asp-action="Index">Reset</a>
+    </div>
+</form>
+
+<div class="card">
+    <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <h2 class="h6 mb-0">Users</h2>
+            <form asp-action="Bulk" method="post" id="bulkForm" class="d-flex gap-2">
+                @Html.AntiForgeryToken()
+                <input type="hidden" name="q" value="@Model.Query" />
+                <input type="hidden" name="orgId" value="@orgValue" />
+                <input type="hidden" name="role" value="@roleValue" />
+                <input type="hidden" name="status" value="@statusValue" />
+                <input type="hidden" name="sortBy" value="@Model.SortBy" />
+                <input type="hidden" name="sortDir" value="@Model.SortDir" />
+                <input type="hidden" name="page" value="@Model.Page" />
+                <input type="hidden" name="pageSize" value="@Model.PageSize" />
+
+                <button type="submit" name="cmd" value="activate" class="btn btn-sm btn-success" disabled id="btnBulkActivate">Activate</button>
+                <button type="submit" name="cmd" value="deactivate" class="btn btn-sm btn-outline-secondary" disabled id="btnBulkDeactivate">Deactivate</button>
+                <button type="submit" name="cmd" value="delete" class="btn btn-sm btn-outline-danger" disabled id="btnBulkDelete">Delete</button>
+            </form>
+        </div>
+
+        <div class="table-responsive">
+            <table class="table table-sm align-middle" id="usersTable">
+                <thead>
+                    <tr>
+                        <th style="width:4%">
+                            <input type="checkbox" id="checkAll" class="form-check-input" />
+                        </th>
+                        <th style="width:20%">
+                            <a class="text-body text-decoration-none"
+                               asp-action="Index"
+                               asp-route-q="@Model.Query"
+                               asp-route-orgId="@(string.IsNullOrEmpty(orgValue) ? null : orgValue)"
+                               asp-route-role="@(string.IsNullOrEmpty(roleValue) ? null : roleValue)"
+                               asp-route-status="@statusValue"
+                               asp-route-sortBy="name"
+                               asp-route-sortDir="@(Model.SortBy == "name" && Model.SortDir == "asc" ? "desc" : "asc")"
+                               asp-route-page="1"
+                               asp-route-pageSize="@Model.PageSize">
+                                Name
+                                <span class="ms-1">@(Model.SortBy == "name" ? (Model.SortDir == "asc" ? "▲" : "▼") : string.Empty)</span>
+                            </a>
+                        </th>
+                        <th style="width:22%">
+                            <a class="text-body text-decoration-none"
+                               asp-action="Index"
+                               asp-route-q="@Model.Query"
+                               asp-route-orgId="@(string.IsNullOrEmpty(orgValue) ? null : orgValue)"
+                               asp-route-role="@(string.IsNullOrEmpty(roleValue) ? null : roleValue)"
+                               asp-route-status="@statusValue"
+                               asp-route-sortBy="email"
+                               asp-route-sortDir="@(Model.SortBy == "email" && Model.SortDir == "asc" ? "desc" : "asc")"
+                               asp-route-page="1"
+                               asp-route-pageSize="@Model.PageSize">
+                                Email
+                                <span class="ms-1">@(Model.SortBy == "email" ? (Model.SortDir == "asc" ? "▲" : "▼") : string.Empty)</span>
+                            </a>
+                        </th>
+                        <th style="width:18%">
+                            <a class="text-body text-decoration-none"
+                               asp-action="Index"
+                               asp-route-q="@Model.Query"
+                               asp-route-orgId="@(string.IsNullOrEmpty(orgValue) ? null : orgValue)"
+                               asp-route-role="@(string.IsNullOrEmpty(roleValue) ? null : roleValue)"
+                               asp-route-status="@statusValue"
+                               asp-route-sortBy="org"
+                               asp-route-sortDir="@(Model.SortBy == "org" && Model.SortDir == "asc" ? "desc" : "asc")"
+                               asp-route-page="1"
+                               asp-route-pageSize="@Model.PageSize">
+                                Organization
+                                <span class="ms-1">@(Model.SortBy == "org" ? (Model.SortDir == "asc" ? "▲" : "▼") : string.Empty)</span>
+                            </a>
+                        </th>
+                        <th style="width:10%">
+                            <a class="text-body text-decoration-none"
+                               asp-action="Index"
+                               asp-route-q="@Model.Query"
+                               asp-route-orgId="@(string.IsNullOrEmpty(orgValue) ? null : orgValue)"
+                               asp-route-role="@(string.IsNullOrEmpty(roleValue) ? null : roleValue)"
+                               asp-route-status="@statusValue"
+                               asp-route-sortBy="role"
+                               asp-route-sortDir="@(Model.SortBy == "role" && Model.SortDir == "asc" ? "desc" : "asc")"
+                               asp-route-page="1"
+                               asp-route-pageSize="@Model.PageSize">
+                                Role
+                                <span class="ms-1">@(Model.SortBy == "role" ? (Model.SortDir == "asc" ? "▲" : "▼") : string.Empty)</span>
+                            </a>
+                        </th>
+                        <th style="width:14%">
+                            <a class="text-body text-decoration-none"
+                               asp-action="Index"
+                               asp-route-q="@Model.Query"
+                               asp-route-orgId="@(string.IsNullOrEmpty(orgValue) ? null : orgValue)"
+                               asp-route-role="@(string.IsNullOrEmpty(roleValue) ? null : roleValue)"
+                               asp-route-status="@statusValue"
+                               asp-route-sortBy="status"
+                               asp-route-sortDir="@(Model.SortBy == "status" && Model.SortDir == "asc" ? "desc" : "asc")"
+                               asp-route-page="1"
+                               asp-route-pageSize="@Model.PageSize">
+                                Status
+                                <span class="ms-1">@(Model.SortBy == "status" ? (Model.SortDir == "asc" ? "▲" : "▼") : string.Empty)</span>
+                            </a>
+                        </th>
+                        <th style="width:12%">
+                            <a class="text-body text-decoration-none"
+                               asp-action="Index"
+                               asp-route-q="@Model.Query"
+                               asp-route-orgId="@(string.IsNullOrEmpty(orgValue) ? null : orgValue)"
+                               asp-route-role="@(string.IsNullOrEmpty(roleValue) ? null : roleValue)"
+                               asp-route-status="@statusValue"
+                               asp-route-sortBy="created"
+                               asp-route-sortDir="@(Model.SortBy == "created" && Model.SortDir == "asc" ? "desc" : "asc")"
+                               asp-route-page="1"
+                               asp-route-pageSize="@Model.PageSize">
+                                Created
+                                <span class="ms-1">@(Model.SortBy == "created" ? (Model.SortDir == "asc" ? "▲" : "▼") : string.Empty)</span>
+                            </a>
+                        </th>
+                        <th style="width:10%"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @if (!Model.Users.Any())
+                    {
+                        <tr>
+                            <td colspan="9" class="text-center text-secondary py-4">No users found.</td>
+                        </tr>
+                    }
+                    else
+                    {
+                        foreach (var user in Model.Users)
+                        {
+                            <tr>
+                                <td>
+                                    <input class="form-check-input row-check" type="checkbox" form="bulkForm" name="ids" value="@user.Id" />
+                                </td>
+                                <td>@user.Name</td>
+                                <td>@user.Email</td>
+                                <td>@user.Organization</td>
+                                <td>@user.Role</td>
+                                <td>
+                                    @if (user.IsActive)
+                                    {
+                                        <span class="badge text-bg-success">Active</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="badge text-bg-secondary">Inactive</span>
+                                    }
+                                    @if (user.IsLocked)
+                                    {
+                                        <span class="badge text-bg-warning text-dark ms-1">Locked</span>
+                                    }
+                                    @if (user.MustChangePassword)
+                                    {
+                                        <span class="badge text-bg-info text-dark ms-1">Must change PW</span>
+                                    }
+                                </td>
+                                <td>@user.CreatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm")</td>
+                                <td class="text-end">
+                                    <a class="btn btn-sm btn-outline-primary" asp-action="Edit" asp-route-id="@user.Id">Edit</a>
+
+                                    <form asp-action="ToggleActive" method="post" class="d-inline">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="id" value="@user.Id" />
+                                        <input type="hidden" name="q" value="@Model.Query" />
+                                        <input type="hidden" name="orgId" value="@orgValue" />
+                                        <input type="hidden" name="role" value="@roleValue" />
+                                        <input type="hidden" name="status" value="@statusValue" />
+                                        <input type="hidden" name="sortBy" value="@Model.SortBy" />
+                                        <input type="hidden" name="sortDir" value="@Model.SortDir" />
+                                        <input type="hidden" name="page" value="@Model.Page" />
+                                        <input type="hidden" name="pageSize" value="@Model.PageSize" />
+                                        <button type="submit" class="btn btn-sm @(user.IsActive ? "btn-outline-secondary" : "btn-success")">
+                                            @(user.IsActive ? "Deactivate" : "Activate")
+                                        </button>
+                                    </form>
+
+                                    <form asp-action="Delete" method="post" class="d-inline" onsubmit="return confirm('Delete this user?');">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="id" value="@user.Id" />
+                                        <input type="hidden" name="q" value="@Model.Query" />
+                                        <input type="hidden" name="orgId" value="@orgValue" />
+                                        <input type="hidden" name="role" value="@roleValue" />
+                                        <input type="hidden" name="status" value="@statusValue" />
+                                        <input type="hidden" name="sortBy" value="@Model.SortBy" />
+                                        <input type="hidden" name="sortDir" value="@Model.SortDir" />
+                                        <input type="hidden" name="page" value="@Model.Page" />
+                                        <input type="hidden" name="pageSize" value="@Model.PageSize" />
+                                        <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        }
+                    }
+                </tbody>
+            </table>
+        </div>
+
+        @if (totalPages > 1)
+        {
+            <nav aria-label="All users pagination">
+                <ul class="pagination pagination-sm mb-0">
+                    <li class="page-item @(Model.Page == 1 ? "disabled" : string.Empty)">
+                        <a class="page-link"
+                           asp-action="Index"
+                           asp-route-q="@Model.Query"
+                           asp-route-orgId="@(string.IsNullOrEmpty(orgValue) ? null : orgValue)"
+                           asp-route-role="@(string.IsNullOrEmpty(roleValue) ? null : roleValue)"
+                           asp-route-status="@statusValue"
+                           asp-route-sortBy="@Model.SortBy"
+                           asp-route-sortDir="@Model.SortDir"
+                           asp-route-page="@(Model.Page - 1)"
+                           asp-route-pageSize="@Model.PageSize">Prev</a>
+                    </li>
+
+                    @for (int p = 1; p <= totalPages; p++)
+                    {
+                        <li class="page-item @(p == Model.Page ? "active" : string.Empty)">
+                            <a class="page-link"
+                               asp-action="Index"
+                               asp-route-q="@Model.Query"
+                               asp-route-orgId="@(string.IsNullOrEmpty(orgValue) ? null : orgValue)"
+                               asp-route-role="@(string.IsNullOrEmpty(roleValue) ? null : roleValue)"
+                               asp-route-status="@statusValue"
+                               asp-route-sortBy="@Model.SortBy"
+                               asp-route-sortDir="@Model.SortDir"
+                               asp-route-page="@p"
+                               asp-route-pageSize="@Model.PageSize">@p</a>
+                        </li>
+                    }
+
+                    <li class="page-item @(Model.Page == totalPages ? "disabled" : string.Empty)">
+                        <a class="page-link"
+                           asp-action="Index"
+                           asp-route-q="@Model.Query"
+                           asp-route-orgId="@(string.IsNullOrEmpty(orgValue) ? null : orgValue)"
+                           asp-route-role="@(string.IsNullOrEmpty(roleValue) ? null : roleValue)"
+                           asp-route-status="@statusValue"
+                           asp-route-sortBy="@Model.SortBy"
+                           asp-route-sortDir="@Model.SortDir"
+                           asp-route-page="@(Model.Page + 1)"
+                           asp-route-pageSize="@Model.PageSize">Next</a>
+                    </li>
+                </ul>
+            </nav>
+        }
+    </div>
+</div>
+
+@section Scripts {
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js" crossorigin="anonymous"></script>
+    <script>
+        (function () {
+            const checkAll = document.getElementById('checkAll');
+            const checks = Array.from(document.querySelectorAll('.row-check'));
+            const btnA = document.getElementById('btnBulkActivate');
+            const btnD = document.getElementById('btnBulkDeactivate');
+            const btnDel = document.getElementById('btnBulkDelete');
+
+            function updateButtons() {
+                const any = checks.some(c => c.checked);
+                if (btnA) btnA.disabled = !any;
+                if (btnD) btnD.disabled = !any;
+                if (btnDel) btnDel.disabled = !any;
+            }
+
+            if (checkAll) {
+                checkAll.addEventListener('change', () => {
+                    checks.forEach(c => c.checked = checkAll.checked);
+                    updateButtons();
+                });
+            }
+
+            checks.forEach(c => c.addEventListener('change', updateButtons));
+            updateButtons();
+        })();
+    </script>
+}

--- a/Views/_ViewImports.cshtml
+++ b/Views/_ViewImports.cshtml
@@ -1,3 +1,4 @@
-﻿@using TrackHive
+@using TrackHive
+@using TrackHive.Models
 
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers


### PR DESCRIPTION
## Summary
- implement a full-featured Super Admin user management controller with filtering, sorting, pagination and bulk actions
- add form view models and Razor pages for listing, creating and editing users across organizations
- surface the new management area in the app navigation and share models with the views

## Testing
- `dotnet build` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca5829f2808328a8ee48c7ead0c733