### PR TITLE
Add webcam capture option for profile photo

### DIFF
--- a/Views/Profile/Index.cshtml
+++ b/Views/Profile/Index.cshtml
@@ -134,10 +134,15 @@
                                 <img id="profilePreviewSmall" class="profile-avatar-img" src="@previewImage" alt="Profile photo preview" data-placeholder="@placeholder" />
                             </div>
                             <div class="d-flex flex-column gap-2">
-                                <label class="btn btn-outline-primary btn-sm mb-0">
-                                    Upload new photo
-                                    <input asp-for="ProfileImage" id="profileImageInput" class="d-none" type="file" accept="image/*" />
-                                </label>
+                                <div class="d-flex flex-wrap gap-2">
+                                    <label class="btn btn-outline-primary btn-sm mb-0">
+                                        Upload new photo
+                                        <input asp-for="ProfileImage" id="profileImageInput" class="d-none" type="file" accept="image/*" />
+                                    </label>
+                                    <button type="button" class="btn btn-outline-secondary btn-sm" id="openCameraBtn">
+                                        Use webcam
+                                    </button>
+                                </div>
                                 <div class="form-check">
                                     <input class="form-check-input" asp-for="RemoveImage" id="removeImageCheck" />
                                     <label class="form-check-label" for="removeImageCheck">Remove current photo</label>
@@ -177,6 +182,27 @@
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
                 <button type="button" class="btn btn-primary" id="applyCropBtn">Apply crop</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="cameraModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Take a photo</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="ratio ratio-4x3 bg-light rounded overflow-hidden">
+                    <video id="cameraVideo" class="w-100 h-100" autoplay muted playsinline></video>
+                </div>
+                <p class="text-danger small mb-0 mt-3" id="cameraError" role="alert"></p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" id="capturePhotoBtn" disabled>Capture photo</button>
             </div>
         </div>
     </div>
@@ -241,19 +267,45 @@
             const cropW = document.getElementById('CropWidth');
             const cropH = document.getElementById('CropHeight');
             const applyBtn = document.getElementById('applyCropBtn');
-            const modal = new bootstrap.Modal(cropperModalEl);
+            const cropperModal = new bootstrap.Modal(cropperModalEl);
+            const openCameraBtn = document.getElementById('openCameraBtn');
+            const cameraModalEl = document.getElementById('cameraModal');
+            const cameraVideo = document.getElementById('cameraVideo');
+            const captureBtn = document.getElementById('capturePhotoBtn');
+            const cameraError = document.getElementById('cameraError');
+            const cameraModal = cameraModalEl ? new bootstrap.Modal(cameraModalEl) : null;
             let cropper;
             let hasAppliedCrop = false;
+            let cameraStream;
 
             const placeholder = previewLarge.dataset.placeholder;
             const placeholderAbsolute = new URL(placeholder, window.location.origin).href;
             const fallback = document.querySelector('.profile-avatar-fallback');
+
+            function stopCameraStream() {
+                if (cameraStream) {
+                    cameraStream.getTracks().forEach(track => track.stop());
+                    cameraStream = null;
+                }
+                if (cameraVideo) {
+                    cameraVideo.srcObject = null;
+                }
+            }
 
             function resetCropData() {
                 cropX.value = '';
                 cropY.value = '';
                 cropW.value = '';
                 cropH.value = '';
+            }
+
+            function showCropperWithDataUrl(dataUrl) {
+                if (!dataUrl) {
+                    return;
+                }
+
+                cropperImage.src = dataUrl;
+                cropperModal.show();
             }
 
             function updatePreview(src) {
@@ -289,12 +341,13 @@
                 }
 
                 hasAppliedCrop = false;
-                removeCheck.checked = false;
+                if (removeCheck) {
+                    removeCheck.checked = false;
+                }
 
                 const reader = new FileReader();
                 reader.onload = function (e) {
-                    cropperImage.src = e.target.result;
-                    modal.show();
+                    showCropperWithDataUrl(e.target.result);
                 };
                 reader.readAsDataURL(file);
             });
@@ -339,7 +392,105 @@
                 updatePreview(previewSrc);
 
                 hasAppliedCrop = true;
-                modal.hide();
+                cropperModal.hide();
+            });
+
+            openCameraBtn?.addEventListener('click', async function () {
+                if (!navigator.mediaDevices?.getUserMedia || !cameraModal) {
+                    alert('Camera access is not supported in this browser.');
+                    return;
+                }
+
+                if (cameraError) {
+                    cameraError.textContent = '';
+                }
+                if (captureBtn) {
+                    captureBtn.disabled = true;
+                }
+                stopCameraStream();
+                cameraModal.show();
+
+                try {
+                    const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'user' } });
+                    cameraStream = stream;
+                    if (cameraVideo) {
+                        cameraVideo.srcObject = stream;
+                        await cameraVideo.play();
+                    }
+                    if (captureBtn) {
+                        captureBtn.disabled = false;
+                    }
+                } catch (err) {
+                    if (cameraError) {
+                        cameraError.textContent = 'Unable to access the camera. Please check your browser permissions and try again.';
+                    }
+                    stopCameraStream();
+                }
+            });
+
+            captureBtn?.addEventListener('click', function () {
+                if (!cameraVideo || !cameraStream) {
+                    return;
+                }
+
+                const width = cameraVideo.videoWidth;
+                const height = cameraVideo.videoHeight;
+
+                if (!width || !height) {
+                    if (cameraError) {
+                        cameraError.textContent = 'Camera is still starting. Please try again in a moment.';
+                    }
+                    return;
+                }
+
+                const canvas = document.createElement('canvas');
+                canvas.width = width;
+                canvas.height = height;
+                const ctx = canvas.getContext('2d');
+                if (!ctx) {
+                    if (cameraError) {
+                        cameraError.textContent = 'Unable to capture photo. Please try again.';
+                    }
+                    return;
+                }
+
+                ctx.drawImage(cameraVideo, 0, 0, width, height);
+
+                canvas.toBlob(blob => {
+                    if (!blob) {
+                        if (cameraError) {
+                            cameraError.textContent = 'Unable to capture photo. Please try again.';
+                        }
+                        return;
+                    }
+
+                    const file = new File([blob], `webcam-${Date.now()}.jpg`, { type: 'image/jpeg' });
+                    const dataTransfer = new DataTransfer();
+                    dataTransfer.items.add(file);
+                    fileInput.files = dataTransfer.files;
+
+                    hasAppliedCrop = false;
+                    if (removeCheck) {
+                        removeCheck.checked = false;
+                    }
+
+                    const dataUrl = canvas.toDataURL('image/jpeg');
+                    stopCameraStream();
+                    if (cameraModal) {
+                        cameraModal.hide();
+                    }
+                    showCropperWithDataUrl(dataUrl);
+                }, 'image/jpeg', 0.95);
+            });
+
+            cameraModalEl?.addEventListener('hidden.bs.modal', function () {
+                stopCameraStream();
+                if (cameraError) {
+                    cameraError.textContent = '';
+                }
+                if (captureBtn) {
+                    captureBtn.disabled = true;
+                }
             });
 
             updatePreview(previewLarge.src && previewLarge.src !== '' ? previewLarge.src : null);


### PR DESCRIPTION
## Summary
- add a webcam capture button and camera modal to the profile photo editor
- hook captured frames into the existing CropperJS flow and preview handling

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ca5e10470c8328bbcc7588432deaf6