### PR TITLE
Add language preference settings and placeholder language packs

### DIFF
--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -293,6 +293,7 @@ public sealed class AuthController : Controller
         var theme = string.Equals(user.ThemePreference, "dark", StringComparison.OrdinalIgnoreCase)
             ? "dark"
             : "light";
+        var language = LanguagePreferences.Normalize(user.LanguagePreference);
         var navOrder = user.NavigationOrder ?? string.Empty;
 
         var claims = new List<System.Security.Claims.Claim>
@@ -302,7 +303,8 @@ public sealed class AuthController : Controller
             new(System.Security.Claims.ClaimTypes.Email, user.Email),
             new(System.Security.Claims.ClaimTypes.Role, user.Role.ToString()),
             new(UserClaimTypes.OrganizationId, user.OrganizationId.ToString()),
-            new(UserClaimTypes.ThemePreference, theme)
+            new(UserClaimTypes.ThemePreference, theme),
+            new(UserClaimTypes.LanguagePreference, language)
         };
 
         if (!string.IsNullOrWhiteSpace(navOrder))

--- a/Controllers/ProfileController.cs
+++ b/Controllers/ProfileController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using SixLabors.ImageSharp;
@@ -59,11 +60,14 @@ public sealed class ProfileController : Controller
         if (user is null) return RedirectToAction("Login", "Auth");
 
         var theme = NormalizeTheme(user.ThemePreference);
+        var language = LanguagePreferences.Normalize(user.LanguagePreference);
         var orderedLinks = NavigationMenu.ApplyOrder(NavigationMenu.GetLinksForRole(user.Role), user.NavigationOrder);
 
         var model = new UserPreferencesViewModel
         {
             Theme = theme,
+            Language = language,
+            Languages = CreateLanguageSelectList(language),
             NavigationLinks = orderedLinks.ToList(),
             NavigationOrder = string.Join(',', orderedLinks.Select(link => link.Id))
         };
@@ -79,12 +83,15 @@ public sealed class ProfileController : Controller
         if (user is null) return RedirectToAction("Login", "Auth");
 
         var theme = NormalizeTheme(model.Theme);
+        var language = LanguagePreferences.Normalize(model.Language);
         var baseLinks = NavigationMenu.GetLinksForRole(user.Role);
         var orderedLinks = NavigationMenu.ApplyOrder(baseLinks, model.NavigationOrder);
         var normalizedOrder = string.Join(',', orderedLinks.Select(link => link.Id));
         var defaultOrder = string.Join(',', baseLinks.Select(link => link.Id));
 
         model.Theme = theme;
+        model.Language = language;
+        model.Languages = CreateLanguageSelectList(language);
         model.NavigationLinks = orderedLinks.ToList();
         model.NavigationOrder = normalizedOrder;
 
@@ -94,6 +101,7 @@ public sealed class ProfileController : Controller
         }
 
         user.ThemePreference = theme;
+        user.LanguagePreference = language;
         user.NavigationOrder = string.IsNullOrEmpty(normalizedOrder) || normalizedOrder == defaultOrder
             ? null
             : normalizedOrder;
@@ -176,6 +184,7 @@ public sealed class ProfileController : Controller
     private async Task RefreshSignInAsync(AppUser user)
     {
         var theme = NormalizeTheme(user.ThemePreference);
+        var language = LanguagePreferences.Normalize(user.LanguagePreference);
         var navOrder = user.NavigationOrder ?? string.Empty;
 
         var claims = new List<Claim>
@@ -185,7 +194,8 @@ public sealed class ProfileController : Controller
             new(ClaimTypes.Email, user.Email),
             new(ClaimTypes.Role, user.Role.ToString()),
             new(UserClaimTypes.OrganizationId, user.OrganizationId.ToString()),
-            new(UserClaimTypes.ThemePreference, theme)
+            new(UserClaimTypes.ThemePreference, theme),
+            new(UserClaimTypes.LanguagePreference, language)
         };
 
         if (!string.IsNullOrWhiteSpace(navOrder))
@@ -204,6 +214,18 @@ public sealed class ProfileController : Controller
 
     private static string NormalizeTheme(string? value) =>
         string.Equals(value, "dark", StringComparison.OrdinalIgnoreCase) ? "dark" : "light";
+
+    private static List<SelectListItem> CreateLanguageSelectList(string selected)
+    {
+        return LanguagePreferences.SupportedLanguages
+            .Select(option => new SelectListItem
+            {
+                Value = option.Value,
+                Text = option.Label,
+                Selected = string.Equals(option.Value, selected, StringComparison.Ordinal)
+            })
+            .ToList();
+    }
 
     private async Task<string?> SaveProfileImageAsync(AppUser user, ProfileViewModel model)
     {

--- a/Models/20251201093000_UserLanguagePreference.Designer.cs
+++ b/Models/20251201093000_UserLanguagePreference.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TrackHive.Models;
 
@@ -11,9 +12,10 @@ using TrackHive.Models;
 namespace TrackHive.Models
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251201093000_UserLanguagePreference")]
+    partial class UserLanguagePreference
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Models/20251201093000_UserLanguagePreference.cs
+++ b/Models/20251201093000_UserLanguagePreference.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TrackHive.Models
+{
+    /// <inheritdoc />
+    public partial class UserLanguagePreference : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "LanguagePreference",
+                table: "Users",
+                type: "nvarchar(10)",
+                maxLength: 10,
+                nullable: false,
+                defaultValue: "en");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LanguagePreference",
+                table: "Users");
+        }
+    }
+}

--- a/Models/AppUser.cs
+++ b/Models/AppUser.cs
@@ -39,6 +39,10 @@ public sealed class AppUser
     [StringLength(20)]
     public string ThemePreference { get; set; } = "light";
 
+    [Required]
+    [StringLength(10)]
+    public string LanguagePreference { get; set; } = "en";
+
     [StringLength(256)]
     public string? NavigationOrder { get; set; }
 

--- a/Models/LanguagePreferences.cs
+++ b/Models/LanguagePreferences.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace TrackHive.Models;
+
+public static class LanguagePreferences
+{
+    public const string DefaultLanguage = "en";
+
+    public static readonly IReadOnlyList<LanguagePreferenceOption> SupportedLanguages = new[]
+    {
+        new LanguagePreferenceOption("en", "English"),
+        new LanguagePreferenceOption("ms", "Malay"),
+        new LanguagePreferenceOption("zh", "Mandarin")
+    };
+
+    public static string Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return DefaultLanguage;
+        }
+
+        foreach (var option in SupportedLanguages)
+        {
+            if (string.Equals(option.Value, value, StringComparison.OrdinalIgnoreCase))
+            {
+                return option.Value;
+            }
+        }
+
+        return DefaultLanguage;
+    }
+}
+
+public sealed record LanguagePreferenceOption(string Value, string Label);

--- a/Models/UserClaimTypes.cs
+++ b/Models/UserClaimTypes.cs
@@ -5,4 +5,5 @@ public static class UserClaimTypes
     public const string OrganizationId = "OrgId";
     public const string ThemePreference = "ThemePreference";
     public const string NavigationOrder = "NavigationOrder";
+    public const string LanguagePreference = "LanguagePreference";
 }

--- a/Models/UserPreferencesViewModel.cs
+++ b/Models/UserPreferencesViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace TrackHive.Models;
 
@@ -7,6 +8,12 @@ public sealed class UserPreferencesViewModel
 {
     [Required]
     public string Theme { get; set; } = "light";
+
+    [Required]
+    [Display(Name = "Language")]
+    public string Language { get; set; } = LanguagePreferences.DefaultLanguage;
+
+    public List<SelectListItem> Languages { get; set; } = new();
 
     public string NavigationOrder { get; set; } = string.Empty;
 

--- a/Views/Profile/Preferences.cshtml
+++ b/Views/Profile/Preferences.cshtml
@@ -37,6 +37,13 @@
                     </div>
 
                     <div class="mb-4">
+                        <label asp-for="Language" class="form-label fw-semibold"></label>
+                        <p class="text-secondary small mb-2">Choose the language used across the TrackHive interface.</p>
+                        <select class="form-select" asp-for="Language" asp-items="Model.Languages"></select>
+                        <span class="text-danger small" asp-validation-for="Language"></span>
+                    </div>
+
+                    <div class="mb-4">
                         <label class="form-label fw-semibold">Navigation menu order</label>
                         <p class="text-secondary small mb-3">Use the arrows to arrange items in the sidebar menu.</p>
 

--- a/Views/Shared/_Layout.App.cshtml
+++ b/Views/Shared/_Layout.App.cshtml
@@ -1,7 +1,9 @@
-@{
+@{ 
     var title = ViewData["Title"] as string ?? "TrackHive";
     var themeClaim = User?.FindFirstValue(UserClaimTypes.ThemePreference) ?? "light";
     var theme = string.Equals(themeClaim, "dark", System.StringComparison.OrdinalIgnoreCase) ? "dark" : "light";
+    var languageClaim = User?.FindFirstValue(UserClaimTypes.LanguagePreference) ?? LanguagePreferences.DefaultLanguage;
+    var language = LanguagePreferences.Normalize(languageClaim);
     var navOrderClaim = User?.FindFirstValue(UserClaimTypes.NavigationOrder);
     var navLinks = new List<NavigationLink>();
 
@@ -12,7 +14,7 @@
     }
 }
 <!doctype html>
-<html lang="en" data-bs-theme="@theme">
+<html lang="@language" data-language="@language" data-bs-theme="@theme">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/wwwroot/lang/en.json
+++ b/wwwroot/lang/en.json
@@ -1,0 +1,5 @@
+{
+  "code": "en",
+  "name": "English",
+  "translations": {}
+}

--- a/wwwroot/lang/ms.json
+++ b/wwwroot/lang/ms.json
@@ -1,0 +1,5 @@
+{
+  "code": "ms",
+  "name": "Malay",
+  "translations": {}
+}

--- a/wwwroot/lang/zh.json
+++ b/wwwroot/lang/zh.json
@@ -1,0 +1,5 @@
+{
+  "code": "zh",
+  "name": "Mandarin",
+  "translations": {}
+}


### PR DESCRIPTION
## Summary
- add a reusable language preference helper with supported English, Malay, and Mandarin options and persist the choice on the user
- extend the profile preferences flow to edit the language, refresh auth claims, and surface the choice in the main layout
- create a database migration and placeholder JSON language packs ready for future translations

## Testing
- `dotnet build` *(fails: dotnet command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7259a2a083288d90cd1fe0ba43c7