### PR TITLE
Add leave submission sound and PWA notifications

### DIFF
--- a/Views/EmployeeDashboard/Index.cshtml
+++ b/Views/EmployeeDashboard/Index.cshtml
@@ -180,7 +180,7 @@
                     <p class="text-secondary small">Pending requests are deducted from your available balance.</p>
                 }
 
-                <form asp-action="ApplyLeave" method="post" class="row g-3 mt-1">
+                <form asp-action="ApplyLeave" method="post" class="row g-3 mt-1" data-leave-application-form>
                     @Html.AntiForgeryToken()
                     <div class="col-sm-6">
                         <label asp-for="LeaveApplication.StartDate" class="form-label">Start</label>
@@ -245,7 +245,11 @@
                             <tbody>
                                 @foreach (var request in Model.LeaveRequests)
                                 {
-                                    <tr>
+                                    <tr data-leave-request-id="@request.Id"
+                                        data-leave-request-status="@request.Status"
+                                        data-leave-request-range="@FormatDateRange(request.StartDate, request.EndDate)"
+                                        data-leave-request-type="@LeaveTypeLabel(request.Type)"
+                                        data-leave-request-days="@request.TotalDays">
                                         <td>
                                             <div>@FormatDateRange(request.StartDate, request.EndDate)</div>
                                             @if (!string.IsNullOrWhiteSpace(request.Reason))
@@ -385,5 +389,6 @@
 
 @section Scripts {
     <script src="~/js/leave-documents.js"></script>
+    <script src="~/js/leave-dashboard.js"></script>
 }
 

--- a/Views/Shared/_Layout.App.cshtml
+++ b/Views/Shared/_Layout.App.cshtml
@@ -19,6 +19,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>@title</title>
+    <meta name="theme-color" content="#0d6efd" />
+    <link rel="manifest" href="~/manifest.webmanifest" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
     <link href="~/css/site.css" rel="stylesheet" />
@@ -84,6 +86,7 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+    <script src="~/js/pwa.js"></script>
     <script>
         (function() {
           const shell = document.getElementById('app-shell');

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -11,6 +11,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>@title</title>
+    <meta name="theme-color" content="#0d6efd" />
+    <link rel="manifest" href="~/manifest.webmanifest" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous" />
     <link href="~/css/site.css" rel="stylesheet" />
     @RenderSection("HeadContent", required: false)
@@ -70,6 +72,7 @@
     </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+    <script src="~/js/pwa.js"></script>
     @RenderSection("Scripts", required: false)
 </body>
 </html>

--- a/wwwroot/img/pwa-icon.svg
+++ b/wwwroot/img/pwa-icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#0d6efd" />
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" rx="48" fill="url(#grad)" />
+  <g fill="#fff" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif">
+    <path d="M76 176c-11 0-20-9-20-20V92c0-11 9-20 20-20h48c11 0 20 9 20 20v20h-24V96H80v64h40v-16h24v12c0 11-9 20-20 20H76z" />
+    <path d="M188 80c22 0 40 18 40 40s-18 40-40 40c-5 0-10-1-14-3l-22 22-17-17 22-22c-2-4-3-9-3-14 0-22 18-40 40-40zm0 24c-9 0-16 7-16 16s7 16 16 16 16-7 16-16-7-16-16-16z" />
+  </g>
+</svg>

--- a/wwwroot/js/leave-dashboard.js
+++ b/wwwroot/js/leave-dashboard.js
@@ -1,0 +1,147 @@
+(function () {
+  'use strict';
+
+  const APPROVED_STATUSES = new Set(['Approved', 'ApprovedAwaitingCertificate']);
+  const STORAGE_KEY = 'trackhive:approved-leave-requests';
+  let audioContext;
+
+  function getAudioContext() {
+    if (audioContext) {
+      return audioContext;
+    }
+
+    const Context = window.AudioContext || window.webkitAudioContext;
+    if (!Context) {
+      return null;
+    }
+
+    audioContext = new Context();
+    return audioContext;
+  }
+
+  function playSubmitSound() {
+    const context = getAudioContext();
+    if (!context) {
+      return;
+    }
+
+    if (context.state === 'suspended') {
+      context.resume().catch(() => { /* Ignore resume errors */ });
+    }
+
+    const now = context.currentTime;
+    const oscillator = context.createOscillator();
+    const gainNode = context.createGain();
+
+    oscillator.type = 'triangle';
+    oscillator.frequency.setValueAtTime(880, now);
+
+    gainNode.gain.setValueAtTime(0.0001, now);
+    gainNode.gain.exponentialRampToValueAtTime(0.09, now + 0.02);
+    gainNode.gain.exponentialRampToValueAtTime(0.0001, now + 0.35);
+
+    oscillator.connect(gainNode);
+    gainNode.connect(context.destination);
+
+    oscillator.start(now);
+    oscillator.stop(now + 0.4);
+  }
+
+  function bindSubmitSound() {
+    const form = document.querySelector('[data-leave-application-form]');
+    if (!form) {
+      return;
+    }
+
+    form.addEventListener('submit', () => {
+      playSubmitSound();
+    });
+  }
+
+  function loadStoredApprovals() {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return new Set();
+      }
+
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) {
+        return new Set();
+      }
+
+      return new Set(parsed.map((value) => String(value)));
+    } catch (error) {
+      console.warn('TrackHive leave approval cache read failed', error);
+      return new Set();
+    }
+  }
+
+  function saveStoredApprovals(ids) {
+    try {
+      const values = Array.from(ids);
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(values));
+    } catch (error) {
+      console.warn('TrackHive leave approval cache write failed', error);
+    }
+  }
+
+  function collectLeaveRows() {
+    return Array.from(document.querySelectorAll('[data-leave-request-id]'));
+  }
+
+  function extractRowDetails(row) {
+    return {
+      id: row.getAttribute('data-leave-request-id'),
+      status: row.getAttribute('data-leave-request-status'),
+      range: row.getAttribute('data-leave-request-range'),
+      type: row.getAttribute('data-leave-request-type'),
+      days: row.getAttribute('data-leave-request-days')
+    };
+  }
+
+  function detectApprovedLeave() {
+    const rows = collectLeaveRows();
+    if (rows.length === 0) {
+      return;
+    }
+
+    const stored = loadStoredApprovals();
+    const currentApproved = new Set();
+    const newlyApproved = [];
+
+    rows.map(extractRowDetails).forEach((detail) => {
+      if (!detail.id) {
+        return;
+      }
+
+      if (APPROVED_STATUSES.has(detail.status)) {
+        currentApproved.add(detail.id);
+        if (!stored.has(detail.id)) {
+          newlyApproved.push(detail);
+        }
+      }
+    });
+
+    saveStoredApprovals(currentApproved);
+
+    if (newlyApproved.length === 0) {
+      return;
+    }
+
+    if (window.TrackHivePWA && typeof window.TrackHivePWA.showLeaveApprovedNotification === 'function') {
+      window.TrackHivePWA.showLeaveApprovedNotification({ details: newlyApproved });
+    }
+  }
+
+  function initialise() {
+    bindSubmitSound();
+    detectApprovedLeave();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initialise);
+  } else {
+    initialise();
+  }
+})();

--- a/wwwroot/js/pwa.js
+++ b/wwwroot/js/pwa.js
@@ -1,0 +1,128 @@
+(function () {
+  'use strict';
+
+  const SERVICE_WORKER_URL = '/service-worker.js';
+  const notificationNamespace = window.TrackHivePWA || {};
+
+  function registerServiceWorker() {
+    if (!('serviceWorker' in navigator)) {
+      return;
+    }
+
+    const register = () => {
+      navigator.serviceWorker
+        .register(SERVICE_WORKER_URL)
+        .catch((error) => console.warn('TrackHive service worker registration failed', error));
+    };
+
+    if (document.readyState === 'complete') {
+      register();
+    } else {
+      window.addEventListener('load', register);
+    }
+  }
+
+  async function requestNotificationPermission() {
+    if (!('Notification' in window)) {
+      return 'denied';
+    }
+
+    if (Notification.permission === 'granted' || Notification.permission === 'denied') {
+      return Notification.permission;
+    }
+
+    try {
+      return await Notification.requestPermission();
+    } catch (error) {
+      console.warn('TrackHive notification permission request failed', error);
+      return Notification.permission;
+    }
+  }
+
+  async function sendMessageToServiceWorker(message) {
+    if (!('serviceWorker' in navigator)) {
+      return false;
+    }
+
+    try {
+      const registration = await navigator.serviceWorker.ready;
+      if (registration.active) {
+        registration.active.postMessage(message);
+        return true;
+      }
+    } catch (error) {
+      console.warn('TrackHive service worker messaging failed', error);
+    }
+
+    return false;
+  }
+
+  async function showLeaveApprovedNotification(payload) {
+    const details = payload && payload.details ? payload.details : [];
+    const count = Array.isArray(details) ? details.length : 0;
+    if (count === 0) {
+      return false;
+    }
+
+    const permission = await requestNotificationPermission();
+    if (permission !== 'granted') {
+      return false;
+    }
+
+    const latest = details[0];
+    const url = '/EmployeeDashboard';
+    const title = count > 1 ? 'Leave requests approved' : 'Leave approved';
+    const range = latest && latest.range ? latest.range : 'your upcoming leave';
+    const type = latest && latest.type ? latest.type : 'leave';
+    const body = count > 1
+      ? `${count} of your leave requests were approved. Latest: ${range} (${type}).`
+      : `Your leave for ${range} (${type}) was approved.`;
+
+    const options = {
+      body,
+      icon: '/img/pwa-icon.svg',
+      badge: '/img/pwa-icon.svg',
+      tag: 'trackhive-leave-approvals',
+      renotify: true,
+      data: { url }
+    };
+
+    if (latest && latest.days) {
+      options.body += ` Duration: ${latest.days} day(s).`;
+    }
+
+    const messageSent = await sendMessageToServiceWorker({
+      type: 'LEAVE_APPROVED_NOTIFICATION',
+      payload: { title, options }
+    });
+
+    if (messageSent) {
+      return true;
+    }
+
+    if ('serviceWorker' in navigator) {
+      try {
+        const registration = await navigator.serviceWorker.getRegistration();
+        if (registration && registration.showNotification) {
+          await registration.showNotification(title, options);
+          return true;
+        }
+      } catch (error) {
+        console.warn('TrackHive direct notification failed', error);
+      }
+    }
+
+    if ('Notification' in window) {
+      new Notification(title, options);
+      return true;
+    }
+
+    return false;
+  }
+
+  notificationNamespace.ensureNotificationPermission = requestNotificationPermission;
+  notificationNamespace.showLeaveApprovedNotification = showLeaveApprovedNotification;
+  window.TrackHivePWA = notificationNamespace;
+
+  registerServiceWorker();
+})();

--- a/wwwroot/manifest.webmanifest
+++ b/wwwroot/manifest.webmanifest
@@ -1,0 +1,22 @@
+{
+  "name": "TrackHive",
+  "short_name": "TrackHive",
+  "description": "TrackHive keeps you connected to your leave and attendance wherever you are.",
+  "lang": "en",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0d6efd",
+  "theme_color": "#0d6efd",
+  "icons": [
+    {
+      "src": "/img/pwa-icon.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/img/pwa-icon.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/wwwroot/service-worker.js
+++ b/wwwroot/service-worker.js
@@ -1,0 +1,89 @@
+const CACHE_NAME = 'trackhive-static-v1';
+const OFFLINE_URLS = [
+  '/',
+  '/css/site.css',
+  '/js/pwa.js',
+  '/js/leave-dashboard.js',
+  '/manifest.webmanifest',
+  '/img/pwa-icon.svg'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then((cache) => cache.addAll(OFFLINE_URLS))
+      .catch((error) => {
+        console.warn('TrackHive service worker install issue', error);
+      })
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) {
+        return cached;
+      }
+
+      return fetch(event.request)
+        .then((response) => {
+          if (!response || response.status !== 200 || response.type !== 'basic') {
+            return response;
+          }
+
+          const cloned = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, cloned));
+          return response;
+        })
+        .catch(() => caches.match('/'));
+    })
+  );
+});
+
+self.addEventListener('message', (event) => {
+  if (!event.data || event.data.type !== 'LEAVE_APPROVED_NOTIFICATION') {
+    return;
+  }
+
+  const { title, options } = event.data.payload || {};
+  if (!title || !options) {
+    return;
+  }
+
+  self.registration.showNotification(title, options);
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const targetUrl = (event.notification.data && event.notification.data.url) || '/';
+
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
+      for (const client of clientList) {
+        if (client.url.includes(targetUrl) && 'focus' in client) {
+          return client.focus();
+        }
+      }
+
+      if (self.clients.openWindow) {
+        return self.clients.openWindow(targetUrl);
+      }
+
+      return undefined;
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- play a lightweight confirmation sound when employees submit new leave requests
- add a web app manifest, service worker and shared PWA helper script to enable installation and caching
- detect newly approved leave items on the employee dashboard and trigger desktop notifications via the service worker

## Testing
- `dotnet build` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7787addc8328bcc7a6f83eb183db