### PR TITLE
Add employee onboarding page with localization

### DIFF
--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -6,4 +6,7 @@ public sealed class HomeController : Controller
 {
     [HttpGet]
     public IActionResult Index() => View();
+
+    [HttpGet]
+    public IActionResult Onboarding() => View();
 }

--- a/Services/NavigationMenu.cs
+++ b/Services/NavigationMenu.cs
@@ -29,6 +29,7 @@ public static class NavigationMenu
             RoleType.Employee => new List<NavigationLink>
             {
                 new("employee-dashboard", "Employee Dashboard", "bi-speedometer2", "EmployeeDashboard", "Index", "Main"),
+                new("onboarding", "Onboarding", "bi-journal-check", "Home", "Onboarding", "Main"),
                 new("preferences", "Preferences", "bi-sliders2", "Profile", "Preferences", "Account"),
                 new("profile", "My profile", "bi-person-circle", "Profile", "Index", "Account"),
             },

--- a/Views/Home/Onboarding.cshtml
+++ b/Views/Home/Onboarding.cshtml
@@ -1,0 +1,115 @@
+@{
+    Layout = "~/Views/Shared/_Layout.App.cshtml";
+    ViewData["Title"] = "Employee onboarding";
+    var languageClaim = User?.FindFirstValue(UserClaimTypes.LanguagePreference);
+    var currentLanguage = LanguagePreferences.Normalize(languageClaim);
+}
+
+<div class="row justify-content-center">
+    <div class="col-xl-9 col-xxl-8">
+        <div class="card shadow-sm border-0 mb-4">
+            <div class="card-body p-4">
+                <div class="d-flex flex-column flex-md-row align-items-md-center gap-4">
+                    <div class="flex-grow-1">
+                        <h1 class="h3 mb-2 fw-semibold text-primary" id="heroTitle">Welcome to TrackHive</h1>
+                        <p class="mb-0 text-secondary" id="heroSubtitle">This onboarding guide introduces our culture, expectations, and the resources that help you thrive.</p>
+                    </div>
+                    <div class="ms-md-auto w-100" style="max-width: 260px;">
+                        <label class="form-label fw-semibold mb-1" for="onboardingLanguage">
+                            <span id="languageLabelText">Display language</span>
+                        </label>
+                        <select class="form-select" id="onboardingLanguage">
+                            @foreach (var option in LanguagePreferences.SupportedLanguages)
+                            {
+                                <option value="@option.Value" @(option.Value == currentLanguage ? "selected" : null)>@option.Label</option>
+                            }
+                        </select>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div id="onboardingError" class="alert alert-danger d-none mb-4" role="alert">
+            Unable to load translations. Please try again.
+        </div>
+
+        <section class="card shadow-sm border-0 mb-4">
+            <div class="card-body p-4">
+                <h2 class="h5 mb-3" id="valuesTitle">Our company values</h2>
+                <p class="text-secondary mb-4" id="valuesDescription">These principles guide how we collaborate and serve our customers.</p>
+                <div class="vstack gap-3" id="valuesList">
+                    <div class="p-3 border rounded">
+                        <h3 class="h6 mb-1">Integrity first</h3>
+                        <p class="mb-0 text-secondary small">We act with honesty, keep our commitments, and own our decisions.</p>
+                    </div>
+                    <div class="p-3 border rounded">
+                        <h3 class="h6 mb-1">Empathy for people</h3>
+                        <p class="mb-0 text-secondary small">We listen carefully to colleagues and customers to understand their needs.</p>
+                    </div>
+                    <div class="p-3 border rounded">
+                        <h3 class="h6 mb-1">Continuous improvement</h3>
+                        <p class="mb-0 text-secondary small">We experiment, learn, and refine the way we work every day.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="card shadow-sm border-0 mb-4">
+            <div class="card-body p-4">
+                <h2 class="h5 mb-3" id="conductTitle">Code of conduct</h2>
+                <p class="text-secondary mb-4" id="conductDescription">Keep these rules in mind as you work with your team.</p>
+                <div class="vstack gap-3" id="conductList">
+                    <div class="p-3 border rounded">
+                        <h3 class="h6 mb-1">Respectful communication</h3>
+                        <p class="mb-0 text-secondary small">Use inclusive language, be punctual, and keep discussions professional.</p>
+                    </div>
+                    <div class="p-3 border rounded">
+                        <h3 class="h6 mb-1">Protect confidential data</h3>
+                        <p class="mb-0 text-secondary small">Never share customer or employee information outside authorized channels.</p>
+                    </div>
+                    <div class="p-3 border rounded">
+                        <h3 class="h6 mb-1">Ask for help early</h3>
+                        <p class="mb-0 text-secondary small">Raise blockers quickly so we can solve them together.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="card shadow-sm border-0 mb-4">
+            <div class="card-body p-4">
+                <h2 class="h5 mb-3" id="safetyTitle">Safety and wellbeing</h2>
+                <p class="text-secondary mb-4" id="safetyDescription">Your wellbeing matters—let us know if something feels unsafe.</p>
+                <div class="vstack gap-3" id="safetyList">
+                    <div class="p-3 border rounded">
+                        <h3 class="h6 mb-1">Workspace ergonomics</h3>
+                        <p class="mb-0 text-secondary small">Adjust your workstation and take short breaks every hour.</p>
+                    </div>
+                    <div class="p-3 border rounded">
+                        <h3 class="h6 mb-1">Security practices</h3>
+                        <p class="mb-0 text-secondary small">Lock your device when away and report suspicious activity immediately.</p>
+                    </div>
+                    <div class="p-3 border rounded">
+                        <h3 class="h6 mb-1">Emergency procedures</h3>
+                        <p class="mb-0 text-secondary small">Follow the building evacuation plan and check in with your lead during drills.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="card shadow-sm border-0">
+            <div class="card-body p-4">
+                <h2 class="h5 mb-3" id="nextStepsTitle">Your next steps</h2>
+                <ol class="ps-3 mb-0" id="nextStepsList">
+                    <li class="mb-2">Meet your mentor during the first week to review role expectations.</li>
+                    <li class="mb-2">Complete required training courses listed in the Learning Portal.</li>
+                    <li class="mb-2">Review project documentation in the shared drive.</li>
+                    <li class="mb-0">Join the #welcome channel to introduce yourself to the team.</li>
+                </ol>
+            </div>
+        </section>
+    </div>
+</div>
+
+@section Scripts {
+    <script src="~/js/onboarding.js"></script>
+}

--- a/wwwroot/js/onboarding.js
+++ b/wwwroot/js/onboarding.js
@@ -1,0 +1,215 @@
+(() => {
+    'use strict';
+
+    const languageSelect = document.getElementById('onboardingLanguage');
+    if (!languageSelect) {
+        return;
+    }
+
+    const heroTitleEl = document.getElementById('heroTitle');
+    const heroSubtitleEl = document.getElementById('heroSubtitle');
+    const languageLabelTextEl = document.getElementById('languageLabelText');
+    const valuesTitleEl = document.getElementById('valuesTitle');
+    const valuesDescriptionEl = document.getElementById('valuesDescription');
+    const valuesListEl = document.getElementById('valuesList');
+    const conductTitleEl = document.getElementById('conductTitle');
+    const conductDescriptionEl = document.getElementById('conductDescription');
+    const conductListEl = document.getElementById('conductList');
+    const safetyTitleEl = document.getElementById('safetyTitle');
+    const safetyDescriptionEl = document.getElementById('safetyDescription');
+    const safetyListEl = document.getElementById('safetyList');
+    const nextStepsTitleEl = document.getElementById('nextStepsTitle');
+    const nextStepsListEl = document.getElementById('nextStepsList');
+    const errorEl = document.getElementById('onboardingError');
+
+    const fallbackLanguage = 'en';
+    const languageCache = new Map();
+
+    let currentLanguage =
+        languageSelect.value ||
+        document.documentElement?.dataset?.language ||
+        fallbackLanguage;
+
+    if (!languageSelect.value) {
+        languageSelect.value = currentLanguage;
+    }
+
+    const setLoading = (isLoading) => {
+        languageSelect.disabled = Boolean(isLoading);
+    };
+
+    const setTextContent = (element, value) => {
+        if (!element || typeof value !== 'string') {
+            return;
+        }
+        element.textContent = value;
+    };
+
+    const renderCardList = (container, items) => {
+        if (!container) {
+            return;
+        }
+
+        container.innerHTML = '';
+
+        if (!Array.isArray(items)) {
+            return;
+        }
+
+        items.forEach((item) => {
+            if (!item) {
+                return;
+            }
+
+            const wrapper = document.createElement('div');
+            wrapper.className = 'p-3 border rounded';
+
+            if (typeof item.title === 'string') {
+                const titleEl = document.createElement('h3');
+                titleEl.className = 'h6 mb-1';
+                titleEl.textContent = item.title;
+                wrapper.appendChild(titleEl);
+            }
+
+            if (typeof item.description === 'string') {
+                const descriptionEl = document.createElement('p');
+                descriptionEl.className = 'mb-0 text-secondary small';
+                descriptionEl.textContent = item.description;
+                wrapper.appendChild(descriptionEl);
+            }
+
+            container.appendChild(wrapper);
+        });
+    };
+
+    const renderOrderedList = (container, items) => {
+        if (!container) {
+            return;
+        }
+
+        container.innerHTML = '';
+
+        if (!Array.isArray(items)) {
+            return;
+        }
+
+        items.forEach((item) => {
+            if (typeof item !== 'string') {
+                return;
+            }
+
+            const listItem = document.createElement('li');
+            listItem.className = 'mb-2';
+            listItem.textContent = item;
+            container.appendChild(listItem);
+        });
+
+        const lastItem = container.lastElementChild;
+        if (lastItem) {
+            lastItem.classList.remove('mb-2');
+            lastItem.classList.add('mb-0');
+        }
+    };
+
+    const showError = (message) => {
+        if (!errorEl) {
+            return;
+        }
+        errorEl.textContent = message;
+        errorEl.classList.remove('d-none');
+    };
+
+    const hideError = () => {
+        if (!errorEl) {
+            return;
+        }
+        errorEl.classList.add('d-none');
+    };
+
+    const applyTranslations = (code, data) => {
+        if (!data) {
+            return;
+        }
+
+        setTextContent(heroTitleEl, data.heroTitle);
+        setTextContent(heroSubtitleEl, data.heroSubtitle);
+        setTextContent(languageLabelTextEl, data.languageLabel);
+        setTextContent(valuesTitleEl, data.valuesTitle);
+        setTextContent(valuesDescriptionEl, data.valuesDescription);
+        renderCardList(valuesListEl, data.values);
+        setTextContent(conductTitleEl, data.conductTitle);
+        setTextContent(conductDescriptionEl, data.conductDescription);
+        renderCardList(conductListEl, data.conduct);
+        setTextContent(safetyTitleEl, data.safetyTitle);
+        setTextContent(safetyDescriptionEl, data.safetyDescription);
+        renderCardList(safetyListEl, data.safety);
+        setTextContent(nextStepsTitleEl, data.nextStepsTitle);
+        renderOrderedList(nextStepsListEl, data.nextSteps);
+
+        languageSelect.value = code;
+        currentLanguage = code;
+    };
+
+    const fetchLanguage = async (code) => {
+        if (languageCache.has(code)) {
+            return languageCache.get(code);
+        }
+
+        const response = await fetch(`/lang/${encodeURIComponent(code)}.json`, {
+            headers: {
+                Accept: 'application/json',
+            },
+        });
+
+        if (!response.ok) {
+            throw new Error(`Unexpected response: ${response.status}`);
+        }
+
+        const payload = await response.json();
+        languageCache.set(code, payload);
+        return payload;
+    };
+
+    const loadLanguage = async (code, allowFallback = true) => {
+        const targetCode = code || fallbackLanguage;
+        setLoading(true);
+
+        try {
+            const payload = await fetchLanguage(targetCode);
+            const translations = payload?.translations?.onboarding;
+            if (!translations) {
+                throw new Error('Missing onboarding translations in language pack');
+            }
+
+            applyTranslations(targetCode, translations);
+            hideError();
+            return true;
+        } catch (error) {
+            console.error('Unable to load onboarding translations', error);
+
+            if (allowFallback && targetCode !== fallbackLanguage) {
+                const fallbackLoaded = await loadLanguage(fallbackLanguage, false);
+                if (fallbackLoaded) {
+                    showError('We could not load the selected language. Showing English instead.');
+                }
+                return false;
+            }
+
+            showError('Unable to load translations. Please try again.');
+            return false;
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    languageSelect.addEventListener('change', (event) => {
+        const code = event.target.value;
+        if (!code || code === currentLanguage) {
+            return;
+        }
+
+        loadLanguage(code);
+    });
+
+    loadLanguage(currentLanguage);
+})();

--- a/wwwroot/lang/en.json
+++ b/wwwroot/lang/en.json
@@ -1,5 +1,66 @@
 {
   "code": "en",
   "name": "English",
-  "translations": {}
+  "translations": {
+    "onboarding": {
+      "heroTitle": "Welcome to TrackHive",
+      "heroSubtitle": "This onboarding guide introduces our culture, expectations, and the resources that help you thrive.",
+      "languageLabel": "Display language",
+      "valuesTitle": "Our company values",
+      "valuesDescription": "These principles guide how we collaborate and serve our customers.",
+      "values": [
+        {
+          "title": "Integrity first",
+          "description": "We act with honesty, keep our commitments, and own our decisions."
+        },
+        {
+          "title": "Empathy for people",
+          "description": "We listen carefully to colleagues and customers to understand their needs."
+        },
+        {
+          "title": "Continuous improvement",
+          "description": "We experiment, learn, and refine the way we work every day."
+        }
+      ],
+      "conductTitle": "Code of conduct",
+      "conductDescription": "Keep these rules in mind as you work with your team.",
+      "conduct": [
+        {
+          "title": "Respectful communication",
+          "description": "Use inclusive language, be punctual, and keep discussions professional."
+        },
+        {
+          "title": "Protect confidential data",
+          "description": "Never share customer or employee information outside authorized channels."
+        },
+        {
+          "title": "Ask for help early",
+          "description": "Raise blockers quickly so we can solve them together."
+        }
+      ],
+      "safetyTitle": "Safety and wellbeing",
+      "safetyDescription": "Your wellbeing matters—let us know if something feels unsafe.",
+      "safety": [
+        {
+          "title": "Workspace ergonomics",
+          "description": "Adjust your workstation and take short breaks every hour."
+        },
+        {
+          "title": "Security practices",
+          "description": "Lock your device when away and report suspicious activity immediately."
+        },
+        {
+          "title": "Emergency procedures",
+          "description": "Follow the building evacuation plan and check in with your lead during drills."
+        }
+      ],
+      "nextStepsTitle": "Your next steps",
+      "nextSteps": [
+        "Meet your mentor during the first week to review role expectations.",
+        "Complete required training courses listed in the Learning Portal.",
+        "Review project documentation in the shared drive.",
+        "Join the #welcome channel to introduce yourself to the team."
+      ]
+    }
+  }
 }

--- a/wwwroot/lang/ms.json
+++ b/wwwroot/lang/ms.json
@@ -1,5 +1,66 @@
 {
   "code": "ms",
   "name": "Malay",
-  "translations": {}
+  "translations": {
+    "onboarding": {
+      "heroTitle": "Selamat datang ke TrackHive",
+      "heroSubtitle": "Panduan orientasi ini memperkenalkan budaya kami, jangkaan kerja, dan sumber yang membantu anda cemerlang.",
+      "languageLabel": "Bahasa paparan",
+      "valuesTitle": "Nilai syarikat kami",
+      "valuesDescription": "Prinsip-prinsip ini memandu cara kami bekerjasama dan melayani pelanggan.",
+      "values": [
+        {
+          "title": "Integriti diutamakan",
+          "description": "Kami bertindak dengan jujur, menunaikan komitmen, dan bertanggungjawab atas keputusan."
+        },
+        {
+          "title": "Empati terhadap orang",
+          "description": "Kami mendengar rakan sekerja dan pelanggan untuk memahami keperluan mereka."
+        },
+        {
+          "title": "Penambahbaikan berterusan",
+          "description": "Kami bereksperimen, belajar, dan menambah baik cara bekerja setiap hari."
+        }
+      ],
+      "conductTitle": "Tatakelakuan",
+      "conductDescription": "Ingat peraturan ini semasa bekerjasama dengan pasukan anda.",
+      "conduct": [
+        {
+          "title": "Komunikasi penuh hormat",
+          "description": "Gunakan bahasa inklusif, tepat masa, dan kekalkan perbincangan profesional."
+        },
+        {
+          "title": "Lindungi data sulit",
+          "description": "Jangan kongsi maklumat pelanggan atau pekerja di luar saluran yang dibenarkan."
+        },
+        {
+          "title": "Minta bantuan awal",
+          "description": "Maklumkan halangan dengan segera supaya kita boleh menyelesaikannya bersama."
+        }
+      ],
+      "safetyTitle": "Keselamatan dan kesejahteraan",
+      "safetyDescription": "Kesejahteraan anda penting—beritahu kami jika sesuatu berasa tidak selamat.",
+      "safety": [
+        {
+          "title": "Ergonomik tempat kerja",
+          "description": "Laraskan stesen kerja dan ambil rehat pendek setiap jam."
+        },
+        {
+          "title": "Amalan keselamatan",
+          "description": "Kunci peranti apabila meninggalkannya dan laporkan aktiviti mencurigakan segera."
+        },
+        {
+          "title": "Prosedur kecemasan",
+          "description": "Ikuti pelan pemindahan bangunan dan lapor kepada penyelia semasa latihan kecemasan."
+        }
+      ],
+      "nextStepsTitle": "Langkah seterusnya anda",
+      "nextSteps": [
+        "Berjumpa mentor anda pada minggu pertama untuk menyemak jangkaan peranan.",
+        "Selesaikan kursus latihan wajib dalam Portal Pembelajaran.",
+        "Semak dokumentasi projek dalam pemacu bersama.",
+        "Sertai saluran #welcome untuk memperkenalkan diri kepada pasukan."
+      ]
+    }
+  }
 }

--- a/wwwroot/lang/zh.json
+++ b/wwwroot/lang/zh.json
@@ -1,5 +1,66 @@
 {
   "code": "zh",
   "name": "Mandarin",
-  "translations": {}
+  "translations": {
+    "onboarding": {
+      "heroTitle": "欢迎加入 TrackHive",
+      "heroSubtitle": "本入职指南将向您介绍公司的文化、工作期望以及帮助您取得成功的资源。",
+      "languageLabel": "显示语言",
+      "valuesTitle": "我们的公司价值观",
+      "valuesDescription": "这些原则指导着我们如何合作以及服务客户。",
+      "values": [
+        {
+          "title": "诚信至上",
+          "description": "我们以诚实行事，信守承诺，并对自己的决定负责。"
+        },
+        {
+          "title": "以人为本的同理心",
+          "description": "我们认真倾听同事和客户的需求。"
+        },
+        {
+          "title": "持续改进",
+          "description": "我们不断尝试、学习，并每天优化工作方式。"
+        }
+      ],
+      "conductTitle": "行为准则",
+      "conductDescription": "与团队合作时请牢记以下规定。",
+      "conduct": [
+        {
+          "title": "尊重的沟通",
+          "description": "使用包容性的语言，守时并保持专业交流。"
+        },
+        {
+          "title": "保护机密数据",
+          "description": "不得在授权渠道之外分享客户或员工信息。"
+        },
+        {
+          "title": "及早寻求帮助",
+          "description": "尽早提出阻碍，以便我们一起解决。"
+        }
+      ],
+      "safetyTitle": "安全与身心健康",
+      "safetyDescription": "我们重视您的身心健康——如有不安全的情况请立即告知。",
+      "safety": [
+        {
+          "title": "工作站人体工学",
+          "description": "调整您的工作站，并且每小时稍作休息。"
+        },
+        {
+          "title": "安全实践",
+          "description": "离开时锁定设备，并立即报告可疑活动。"
+        },
+        {
+          "title": "应急程序",
+          "description": "遵循大楼疏散方案，并在演练期间向负责人报到。"
+        }
+      ],
+      "nextStepsTitle": "接下来的步骤",
+      "nextSteps": [
+        "在第一周与导师会面，了解岗位期望。",
+        "完成学习平台中列出的必修培训课程。",
+        "阅读共享云盘中的项目文档。",
+        "加入 #welcome 频道，向团队做自我介绍。"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add an employee onboarding page that uses the app layout
- populate English, Malay, and Mandarin language packs with onboarding content
- wire navigation, controller, and a client script to swap the displayed language

## Testing
- dotnet build *(fails: dotnet: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7a07addc832894326090a89cda84