### PR TITLE
Add HR metrics charts with PDF export

### DIFF
--- a/Controllers/HrDashboardController.cs
+++ b/Controllers/HrDashboardController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
@@ -329,6 +330,15 @@ public sealed class HrDashboardController : Controller
         var org = await _db.Organizations.AsNoTracking().FirstOrDefaultAsync(o => o.Id == hr.OrganizationId);
         var invite = inviteOverride ?? new InviteEmployeeViewModel();
 
+        static string FormatLeaveType(LeaveType type) => type switch
+        {
+            LeaveType.Annual => "Annual leave",
+            LeaveType.Sick => "Sick leave",
+            LeaveType.Emergency => "Emergency leave",
+            LeaveType.Unpaid => "Unpaid leave",
+            _ => "Other leave"
+        };
+
         var employees = await _db.Users
             .AsNoTracking()
             .Where(u => u.OrganizationId == hr.OrganizationId && u.Role == RoleType.Employee)
@@ -606,6 +616,111 @@ public sealed class HrDashboardController : Controller
             .Take(10)
             .ToList();
 
+        var currentMonthUtc = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+        var monthRange = Enumerable.Range(0, 6)
+            .Select(offset => currentMonthUtc.AddMonths(offset - 5))
+            .Select(date => new
+            {
+                Date = date,
+                Label = date.ToString("MMM yyyy", CultureInfo.InvariantCulture)
+            })
+            .ToList();
+
+        var monthlyTrends = new List<MonthlyLeaveTrendViewModel>();
+        var leaveTypeBreakdown = new List<LeaveTypeBreakdownViewModel>();
+        var leavesReviewedThisMonth = 0;
+
+        if (employeeIds.Count > 0)
+        {
+            var earliestMonth = monthRange.First().Date;
+            var leaveHistory = await _db.LeaveRequests
+                .AsNoTracking()
+                .Where(r => employeeIds.Contains(r.UserId) && r.CreatedAt >= earliestMonth)
+                .Select(r => new { r.CreatedAt, r.Status })
+                .ToListAsync();
+
+            var monthlyLookup = leaveHistory
+                .GroupBy(r => new DateTime(r.CreatedAt.Year, r.CreatedAt.Month, 1, 0, 0, 0, DateTimeKind.Utc))
+                .ToDictionary(
+                    g => g.Key,
+                    g =>
+                    {
+                        var pending = g.Count(x => x.Status == LeaveRequestStatus.Pending || x.Status == LeaveRequestStatus.AwaitingCertificateReview);
+                        var approved = g.Count(x => x.Status == LeaveRequestStatus.Approved || x.Status == LeaveRequestStatus.ApprovedAwaitingCertificate);
+                        var rejected = g.Count(x => x.Status == LeaveRequestStatus.Rejected || x.Status == LeaveRequestStatus.CertificateRejected);
+                        return (Pending: pending, Approved: approved, Rejected: rejected);
+                    });
+
+            foreach (var info in monthRange)
+            {
+                if (monthlyLookup.TryGetValue(info.Date, out var counts))
+                {
+                    monthlyTrends.Add(new MonthlyLeaveTrendViewModel
+                    {
+                        MonthLabel = info.Label,
+                        Pending = counts.Pending,
+                        Approved = counts.Approved,
+                        Rejected = counts.Rejected
+                    });
+
+                    if (info.Date == currentMonthUtc)
+                    {
+                        leavesReviewedThisMonth = counts.Approved + counts.Rejected;
+                    }
+                }
+                else
+                {
+                    monthlyTrends.Add(new MonthlyLeaveTrendViewModel
+                    {
+                        MonthLabel = info.Label,
+                        Pending = 0,
+                        Approved = 0,
+                        Rejected = 0
+                    });
+                }
+            }
+
+            var typeCounts = await _db.LeaveRequests
+                .AsNoTracking()
+                .Where(r => employeeIds.Contains(r.UserId))
+                .GroupBy(r => r.Type)
+                .Select(g => new { Type = g.Key, Count = g.Count() })
+                .ToListAsync();
+
+            leaveTypeBreakdown = typeCounts
+                .OrderByDescending(t => t.Count)
+                .Select(t => new LeaveTypeBreakdownViewModel
+                {
+                    Type = FormatLeaveType(t.Type),
+                    Count = t.Count
+                })
+                .ToList();
+        }
+
+        if (monthlyTrends.Count == 0)
+        {
+            monthlyTrends = monthRange
+                .Select(info => new MonthlyLeaveTrendViewModel
+                {
+                    MonthLabel = info.Label,
+                    Pending = 0,
+                    Approved = 0,
+                    Rejected = 0
+                })
+                .ToList();
+        }
+
+        var metrics = new DashboardMetricsViewModel
+        {
+            TotalEmployees = employees.Count,
+            PendingLeaveApprovals = pendingViewModels.Count,
+            PendingCertificateReviews = certificateViewModels.Count,
+            AwaitingEmployeeCertificates = awaitingEmployeeCertificates.Count,
+            LeavesReviewedThisMonth = leavesReviewedThisMonth,
+            LeaveTrends = monthlyTrends,
+            LeaveTypeBreakdown = leaveTypeBreakdown
+        };
+
         return new HrDashboardViewModel
         {
             OrganizationName = org?.Name ?? "Organization",
@@ -613,7 +728,8 @@ public sealed class HrDashboardController : Controller
             PendingLeaveRequests = pendingViewModels,
             PendingCertificateRequests = certificateViewModels,
             LeaveSummaries = leaveSummaries,
-            Notifications = orderedNotifications
+            Notifications = orderedNotifications,
+            Metrics = metrics
         };
     }
 

--- a/Models/HrDashboardViewModel.cs
+++ b/Models/HrDashboardViewModel.cs
@@ -8,6 +8,7 @@ public sealed class HrDashboardViewModel
     public IReadOnlyList<LeaveCertificateReviewViewModel> PendingCertificateRequests { get; init; } = Array.Empty<LeaveCertificateReviewViewModel>();
     public IReadOnlyList<LeaveBalanceSummaryViewModel> LeaveSummaries { get; init; } = Array.Empty<LeaveBalanceSummaryViewModel>();
     public IReadOnlyList<DashboardNotificationViewModel> Notifications { get; init; } = Array.Empty<DashboardNotificationViewModel>();
+    public DashboardMetricsViewModel Metrics { get; init; } = new();
 }
 
 public sealed class LeaveRequestReviewViewModel
@@ -51,5 +52,30 @@ public sealed class DashboardNotificationViewModel
     public required string Message { get; init; }
     public required string Category { get; init; }
     public DateTimeOffset? CreatedAt { get; init; }
+}
+
+public sealed class DashboardMetricsViewModel
+{
+    public int TotalEmployees { get; init; }
+    public int PendingLeaveApprovals { get; init; }
+    public int PendingCertificateReviews { get; init; }
+    public int AwaitingEmployeeCertificates { get; init; }
+    public int LeavesReviewedThisMonth { get; init; }
+    public IReadOnlyList<MonthlyLeaveTrendViewModel> LeaveTrends { get; init; } = Array.Empty<MonthlyLeaveTrendViewModel>();
+    public IReadOnlyList<LeaveTypeBreakdownViewModel> LeaveTypeBreakdown { get; init; } = Array.Empty<LeaveTypeBreakdownViewModel>();
+}
+
+public sealed class MonthlyLeaveTrendViewModel
+{
+    public required string MonthLabel { get; init; }
+    public int Pending { get; init; }
+    public int Approved { get; init; }
+    public int Rejected { get; init; }
+}
+
+public sealed class LeaveTypeBreakdownViewModel
+{
+    public required string Type { get; init; }
+    public int Count { get; init; }
 }
 

--- a/Views/HrDashboard/Index.cshtml
+++ b/Views/HrDashboard/Index.cshtml
@@ -1,8 +1,14 @@
+@using System.Text.Json
 @model TrackHive.Models.HrDashboardViewModel
 @{
     ViewData["Title"] = "HR Dashboard";
     Layout = "~/Views/Shared/_Layout.App.cshtml";
     var orgName = Model.OrganizationName;
+    var metrics = Model.Metrics;
+    var metricsJson = JsonSerializer.Serialize(metrics, new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    });
     var certificateMessage = TempData["CertificateActionMessage"] as string;
     var certificateError = TempData["CertificateActionError"] as string;
     string FormatDate(DateOnly value) => value.ToString("MMM d, yyyy");
@@ -30,6 +36,87 @@
             <div class="card-body p-4">
                 <h1 class="h5 mb-2">Welcome, HR</h1>
                 <div class="text-secondary">Organization: <strong>@orgName</strong></div>
+            </div>
+        </div>
+
+        <div class="card shadow-sm mb-4" id="hrMetricsCard">
+            <div class="card-body p-4">
+                <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center mb-4">
+                    <div>
+                        <h2 class="h5 mb-1">Organization metrics</h2>
+                        <div class="text-secondary small">Leave performance overview for the past six months.</div>
+                    </div>
+                    <div class="ms-md-auto">
+                        <button type="button" class="btn btn-outline-primary btn-sm" id="exportMetricsBtn">
+                            <i class="bi bi-download me-1" aria-hidden="true"></i>
+                            <span>Export as PDF</span>
+                        </button>
+                    </div>
+                </div>
+
+                <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-3 mb-4">
+                    <div class="col">
+                        <div class="border rounded-3 p-3 h-100">
+                            <div class="text-secondary text-uppercase small">Total employees</div>
+                            <div class="fs-3 fw-semibold mb-0">@metrics.TotalEmployees</div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="border rounded-3 p-3 h-100">
+                            <div class="text-secondary text-uppercase small">Pending approvals</div>
+                            <div class="fs-3 fw-semibold mb-0">@metrics.PendingLeaveApprovals</div>
+                            <div class="text-secondary small">Awaiting HR decision</div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="border rounded-3 p-3 h-100">
+                            <div class="text-secondary text-uppercase small">Certificates to review</div>
+                            <div class="fs-3 fw-semibold mb-0">@metrics.PendingCertificateReviews</div>
+                            <div class="text-secondary small">Employee documents uploaded</div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="border rounded-3 p-3 h-100">
+                            <div class="text-secondary text-uppercase small">Leaves reviewed</div>
+                            <div class="fs-3 fw-semibold mb-0">@metrics.LeavesReviewedThisMonth</div>
+                            <div class="text-secondary small">Approved or rejected this month</div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="border rounded-3 p-3 h-100 @(metrics.AwaitingEmployeeCertificates > 0 ? "border-warning-subtle bg-warning-subtle" : string.Empty)">
+                            <div class="text-secondary text-uppercase small">Waiting on certificates</div>
+                            <div class="fs-3 fw-semibold mb-0">@metrics.AwaitingEmployeeCertificates</div>
+                            <div class="text-secondary small">Approved leave pending documents</div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="mt-4">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <h3 class="h6 mb-0">Leave decisions by month</h3>
+                        <span class="text-secondary small">Past six months</span>
+                    </div>
+                    <div class="ratio ratio-21x9 bg-body-tertiary rounded-3">
+                        <canvas id="leaveTrendChart" role="img" aria-label="Line chart showing leave decisions by month"></canvas>
+                    </div>
+                </div>
+
+                <div class="mt-4">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <h3 class="h6 mb-0">Leave type distribution</h3>
+                        <span class="text-secondary small">All recorded requests</span>
+                    </div>
+                    @if (metrics.LeaveTypeBreakdown.Count == 0)
+                    {
+                        <p class="text-secondary small mb-0">No leave requests have been recorded yet.</p>
+                    }
+                    else
+                    {
+                        <div class="ratio ratio-1x1 bg-body-tertiary rounded-3">
+                            <canvas id="leaveTypeChart" role="img" aria-label="Doughnut chart showing leave type distribution"></canvas>
+                        </div>
+                    }
+                </div>
             </div>
         </div>
 
@@ -331,4 +418,181 @@
         </div>
     </div>
 </div>
+
+@section Scripts {
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js" crossorigin="anonymous"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const metrics = @Html.Raw(metricsJson);
+            const metricsCard = document.getElementById('hrMetricsCard');
+
+            if (!metricsCard) {
+                return;
+            }
+
+            const trendCanvas = metricsCard.querySelector('#leaveTrendChart');
+            if (trendCanvas && window.Chart && Array.isArray(metrics.leaveTrends)) {
+                const labels = metrics.leaveTrends.map(trend => trend.monthLabel);
+                const pendingData = metrics.leaveTrends.map(trend => trend.pending);
+                const approvedData = metrics.leaveTrends.map(trend => trend.approved);
+                const rejectedData = metrics.leaveTrends.map(trend => trend.rejected);
+
+                new window.Chart(trendCanvas, {
+                    type: 'line',
+                    data: {
+                        labels,
+                        datasets: [
+                            {
+                                label: 'Pending',
+                                data: pendingData,
+                                tension: 0.35,
+                                borderColor: '#f59f00',
+                                backgroundColor: 'rgba(245, 159, 0, 0.2)',
+                                fill: true,
+                                borderWidth: 2,
+                                pointRadius: 3
+                            },
+                            {
+                                label: 'Approved',
+                                data: approvedData,
+                                tension: 0.35,
+                                borderColor: '#198754',
+                                backgroundColor: 'rgba(25, 135, 84, 0.15)',
+                                fill: true,
+                                borderWidth: 2,
+                                pointRadius: 3
+                            },
+                            {
+                                label: 'Rejected',
+                                data: rejectedData,
+                                tension: 0.35,
+                                borderColor: '#dc3545',
+                                backgroundColor: 'rgba(220, 53, 69, 0.15)',
+                                fill: true,
+                                borderWidth: 2,
+                                pointRadius: 3
+                            }
+                        ]
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        interaction: {
+                            intersect: false,
+                            mode: 'index'
+                        },
+                        plugins: {
+                            legend: {
+                                position: 'bottom'
+                            },
+                            tooltip: {
+                                callbacks: {
+                                    label(context) {
+                                        return `${context.dataset.label}: ${context.parsed.y}`;
+                                    }
+                                }
+                            }
+                        },
+                        scales: {
+                            y: {
+                                beginAtZero: true,
+                                ticks: {
+                                    precision: 0
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+
+            const typeCanvas = metricsCard.querySelector('#leaveTypeChart');
+            if (typeCanvas && window.Chart && Array.isArray(metrics.leaveTypeBreakdown) && metrics.leaveTypeBreakdown.length > 0) {
+                const labels = metrics.leaveTypeBreakdown.map(item => item.type);
+                const data = metrics.leaveTypeBreakdown.map(item => item.count);
+
+                new window.Chart(typeCanvas, {
+                    type: 'doughnut',
+                    data: {
+                        labels,
+                        datasets: [
+                            {
+                                data,
+                                backgroundColor: [
+                                    '#0d6efd',
+                                    '#20c997',
+                                    '#fd7e14',
+                                    '#6f42c1',
+                                    '#adb5bd'
+                                ],
+                                borderWidth: 1
+                            }
+                        ]
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        plugins: {
+                            legend: {
+                                position: 'bottom'
+                            }
+                        }
+                    }
+                });
+            }
+
+            const exportButton = document.getElementById('exportMetricsBtn');
+            if (exportButton) {
+                const defaultHtml = exportButton.innerHTML;
+
+                exportButton.addEventListener('click', async () => {
+                    if (!window.html2canvas || !window.jspdf) {
+                        window.alert('Export is currently unavailable. Please try again later.');
+                        return;
+                    }
+
+                    exportButton.disabled = true;
+                    exportButton.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>Preparing PDF...';
+
+                    try {
+                        const canvas = await window.html2canvas(metricsCard, {
+                            scale: window.devicePixelRatio > 1 ? window.devicePixelRatio : 2,
+                            useCORS: true,
+                            backgroundColor: window.getComputedStyle(document.body).backgroundColor
+                        });
+
+                        const imgData = canvas.toDataURL('image/png');
+                        const { jsPDF } = window.jspdf;
+                        const pdf = new jsPDF('p', 'mm', 'a4');
+                        const pageWidth = pdf.internal.pageSize.getWidth();
+                        const pageHeight = pdf.internal.pageSize.getHeight();
+                        const imgProps = pdf.getImageProperties(imgData);
+
+                        const margin = 10;
+                        let pdfWidth = pageWidth - margin * 2;
+                        let pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
+
+                        if (pdfHeight > pageHeight - margin * 2) {
+                            pdfHeight = pageHeight - margin * 2;
+                            pdfWidth = (imgProps.width * pdfHeight) / imgProps.height;
+                        }
+
+                        const offsetX = (pageWidth - pdfWidth) / 2;
+                        pdf.addImage(imgData, 'PNG', offsetX, margin, pdfWidth, pdfHeight);
+
+                        const timestamp = new Date().toISOString().slice(0, 10);
+                        pdf.save(`trackhive-hr-metrics-${timestamp}.pdf`);
+                    } catch (error) {
+                        console.error('Metrics export failed', error);
+                        window.alert('We could not export the metrics. Please try again.');
+                    } finally {
+                        exportButton.disabled = false;
+                        exportButton.innerHTML = defaultHtml;
+                    }
+                });
+            }
+        });
+    </script>
+}
 


### PR DESCRIPTION
## Summary
- extend the HR dashboard view model with aggregated metric structures for charting
- calculate six-month leave trends and leave type breakdowns in the HR dashboard controller
- enrich the HR dashboard page with Chart.js visualisations and a PDF export option for the metrics card

## Testing
- `dotnet build` *(fails: command not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca84c54b548328877364264836ca39