### PR TITLE
Add email redundancy for leave workflow notifications

### DIFF
--- a/Controllers/EmployeeDashboardController.cs
+++ b/Controllers/EmployeeDashboardController.cs
@@ -1,6 +1,8 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Security.Claims;
+using System.Text;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -21,11 +23,13 @@ public sealed class EmployeeDashboardController : Controller
     private const long MaxCertificateFileBytes = 5 * 1024 * 1024; // 5 MB per file
     private static readonly string[] AllowedCertificateExtensions = [".jpg", ".jpeg", ".png", ".gif", ".bmp", ".pdf", ".heic", ".heif"];
     private readonly IWebHostEnvironment _environment;
+    private readonly EmailService _email;
 
-    public EmployeeDashboardController(AppDbContext db, IWebHostEnvironment environment)
+    public EmployeeDashboardController(AppDbContext db, IWebHostEnvironment environment, EmailService email)
     {
         _db = db;
         _environment = environment;
+        _email = email;
     }
 
     [HttpGet]
@@ -191,6 +195,12 @@ public sealed class EmployeeDashboardController : Controller
         var idStr = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (!int.TryParse(idStr, out var id)) return RedirectToAction("Login", "Auth");
 
+        var employee = await _db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == id);
+        if (employee is null)
+        {
+            return RedirectToAction("Login", "Auth");
+        }
+
         if (model.StartDate is null || model.EndDate is null)
         {
             TempData[LeaveErrorKey] = "Start and end dates are required.";
@@ -263,6 +273,36 @@ public sealed class EmployeeDashboardController : Controller
         {
             await _db.SaveChangesAsync();
             TempData[LeaveMessageKey] = $"Leave request submitted for {totalDays} day(s).";
+
+            var hrError = await NotifyHrsAsync(employee.OrganizationId, hr =>
+            {
+                var subject = $"New leave request from {employee.Name}";
+                var reviewUrl = Url.Action("Index", "HrDashboard", values: null, protocol: Request.Scheme, host: Request.Host.Value);
+                var builder = new StringBuilder();
+                builder.Append($"<p>Hi {System.Net.WebUtility.HtmlEncode(hr.Name)},</p>");
+                builder.Append($"<p>{System.Net.WebUtility.HtmlEncode(employee.Name)} submitted a leave request.</p>");
+                builder.Append("<p><strong>Leave details:</strong><br/>");
+                builder.Append($"Type: {System.Net.WebUtility.HtmlEncode(FormatLeaveType(request.Type))}<br/>");
+                builder.Append($"Dates: {request.StartDate:MMM d, yyyy} – {request.EndDate:MMM d, yyyy}<br/>");
+                builder.Append($"Total days: {request.TotalDays}</p>");
+                if (!string.IsNullOrWhiteSpace(request.Reason))
+                {
+                    builder.Append($"<p><strong>Reason:</strong> {System.Net.WebUtility.HtmlEncode(request.Reason)}</p>");
+                }
+
+                if (!string.IsNullOrWhiteSpace(reviewUrl))
+                {
+                    builder.Append($"<p>Review in TrackHive: <a href=\"{reviewUrl}\">{reviewUrl}</a></p>");
+                }
+
+                builder.Append("<p>— TrackHive</p>");
+                return (subject, builder.ToString());
+            });
+
+            if (!string.IsNullOrWhiteSpace(hrError))
+            {
+                TempData[LeaveErrorKey] = $"Leave request submitted, but we couldn't send notification email(s): {hrError}";
+            }
         }
         catch (DbUpdateException)
         {
@@ -281,6 +321,7 @@ public sealed class EmployeeDashboardController : Controller
 
         var request = await _db.LeaveRequests
             .Include(r => r.Documents)
+            .Include(r => r.User)
             .FirstOrDefaultAsync(r => r.Id == requestId && r.UserId == userId);
 
         if (request is null)
@@ -349,6 +390,35 @@ public sealed class EmployeeDashboardController : Controller
         {
             await _db.SaveChangesAsync();
             TempData[CertificateMessageKey] = "Medical certificate submitted for HR review.";
+
+            if (request.User is not null)
+            {
+                var hrError = await NotifyHrsAsync(request.User.OrganizationId, hr =>
+                {
+                    var subject = $"Medical certificate from {request.User.Name}";
+                    var reviewUrl = Url.Action("Index", "HrDashboard", values: null, protocol: Request.Scheme, host: Request.Host.Value);
+                    var builder = new StringBuilder();
+                    builder.Append($"<p>Hi {System.Net.WebUtility.HtmlEncode(hr.Name)},</p>");
+                    builder.Append($"<p>{System.Net.WebUtility.HtmlEncode(request.User.Name)} uploaded a medical certificate for their leave request.</p>");
+                    builder.Append("<p><strong>Leave details:</strong><br/>");
+                    builder.Append($"Type: {System.Net.WebUtility.HtmlEncode(FormatLeaveType(request.Type))}<br/>");
+                    builder.Append($"Dates: {request.StartDate:MMM d, yyyy} – {request.EndDate:MMM d, yyyy}<br/>");
+                    builder.Append($"Total days: {request.TotalDays}</p>");
+
+                    if (!string.IsNullOrWhiteSpace(reviewUrl))
+                    {
+                        builder.Append($"<p>Review the documents: <a href=\"{reviewUrl}\">{reviewUrl}</a></p>");
+                    }
+
+                    builder.Append("<p>— TrackHive</p>");
+                    return (subject, builder.ToString());
+                });
+
+                if (!string.IsNullOrWhiteSpace(hrError))
+                {
+                    TempData[CertificateErrorKey] = $"Medical certificate submitted, but we couldn't send notification email(s): {hrError}";
+                }
+            }
         }
         catch (DbUpdateException)
         {
@@ -500,4 +570,46 @@ public sealed class EmployeeDashboardController : Controller
 
         return name[^256..];
     }
+
+    private async Task<string?> NotifyHrsAsync(int organizationId, Func<AppUser, (string Subject, string Body)> messageFactory)
+    {
+        var hrUsers = await _db.Users
+            .AsNoTracking()
+            .Where(u => u.OrganizationId == organizationId && u.Role == RoleType.HR && u.IsActive)
+            .ToListAsync();
+
+        if (hrUsers.Count == 0)
+        {
+            return null;
+        }
+
+        var failures = new List<string>();
+
+        foreach (var hr in hrUsers)
+        {
+            if (string.IsNullOrWhiteSpace(hr.Email))
+            {
+                continue;
+            }
+
+            var (subject, body) = messageFactory(hr);
+            var (ok, error) = await _email.SendAsync(hr.Email, subject, body);
+            if (!ok)
+            {
+                var detail = string.IsNullOrWhiteSpace(error) ? hr.Email : $"{hr.Email}: {error}";
+                failures.Add(detail);
+            }
+        }
+
+        return failures.Count == 0 ? null : string.Join("; ", failures);
+    }
+
+    private static string FormatLeaveType(LeaveType type) => type switch
+    {
+        LeaveType.Annual    => "Annual leave",
+        LeaveType.Sick      => "Sick leave",
+        LeaveType.Emergency => "Emergency leave",
+        LeaveType.Unpaid    => "Unpaid leave",
+        _                   => "Other leave"
+    };
 }

--- a/Controllers/HrDashboardController.cs
+++ b/Controllers/HrDashboardController.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Linq;
 using System.Security.Claims;
+using System.Text;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -18,6 +19,14 @@ public sealed class HrDashboardController : Controller
     private const string LeaveActionErrorKey   = "LeaveActionError";
     private const string CertificateActionMessageKey = "CertificateActionMessage";
     private const string CertificateActionErrorKey   = "CertificateActionError";
+    private static string FormatLeaveType(LeaveType type) => type switch
+    {
+        LeaveType.Annual    => "Annual leave",
+        LeaveType.Sick      => "Sick leave",
+        LeaveType.Emergency => "Emergency leave",
+        LeaveType.Unpaid    => "Unpaid leave",
+        _                   => "Other leave"
+    };
     public HrDashboardController(AppDbContext db, EmailService email)
     {
         _db = db;
@@ -185,6 +194,21 @@ public sealed class HrDashboardController : Controller
                 ? $"Approved {request.User.Name}'s leave ({request.TotalDays} day(s)). Awaiting medical certificate."
                 : $"Approved {request.User.Name}'s leave ({request.TotalDays} day(s)).";
             TempData[LeaveActionMessageKey] = message;
+
+            var subject = "Leave request approved";
+            var intro = "Good news! Your leave request has been approved.";
+            var additional = requiresCertificate
+                ? "Please upload your medical certificate so HR can complete the approval."
+                : null;
+
+            var (emailOk, emailError) = await SendEmployeeLeaveEmailAsync(request, subject, intro, additional);
+            if (!emailOk)
+            {
+                var errorMessage = string.IsNullOrWhiteSpace(emailError)
+                    ? "Leave approved, but the email notification could not be sent."
+                    : $"Leave approved, but the email notification could not be sent: {emailError}";
+                TempData[LeaveActionErrorKey] = errorMessage;
+            }
         }
         catch (DbUpdateException)
         {
@@ -226,6 +250,19 @@ public sealed class HrDashboardController : Controller
         {
             await _db.SaveChangesAsync();
             TempData[LeaveActionMessageKey] = $"Rejected {request.User.Name}'s leave request.";
+
+            var (emailOk, emailError) = await SendEmployeeLeaveEmailAsync(
+                request,
+                "Leave request rejected",
+                "We're sorry to let you know that your leave request was rejected.");
+
+            if (!emailOk)
+            {
+                var errorMessage = string.IsNullOrWhiteSpace(emailError)
+                    ? "Leave rejected, but the email notification could not be sent."
+                    : $"Leave rejected, but the email notification could not be sent: {emailError}";
+                TempData[LeaveActionErrorKey] = errorMessage;
+            }
         }
         catch (DbUpdateException)
         {
@@ -267,6 +304,19 @@ public sealed class HrDashboardController : Controller
         {
             await _db.SaveChangesAsync();
             TempData[CertificateActionMessageKey] = $"Approved medical certificate for {request.User.Name}.";
+
+            var (emailOk, emailError) = await SendEmployeeLeaveEmailAsync(
+                request,
+                "Medical certificate approved",
+                "Your medical certificate has been reviewed and your leave is fully approved.");
+
+            if (!emailOk)
+            {
+                var errorMessage = string.IsNullOrWhiteSpace(emailError)
+                    ? "Certificate approved, but the email notification could not be sent."
+                    : $"Certificate approved, but the email notification could not be sent: {emailError}";
+                TempData[CertificateActionErrorKey] = errorMessage;
+            }
         }
         catch (DbUpdateException)
         {
@@ -308,6 +358,20 @@ public sealed class HrDashboardController : Controller
         {
             await _db.SaveChangesAsync();
             TempData[CertificateActionMessageKey] = $"Requested a new medical certificate from {request.User.Name}.";
+
+            var (emailOk, emailError) = await SendEmployeeLeaveEmailAsync(
+                request,
+                "Medical certificate requires attention",
+                "We reviewed your medical certificate but couldn't approve it.",
+                "Please upload a new document so we can complete the approval.");
+
+            if (!emailOk)
+            {
+                var errorMessage = string.IsNullOrWhiteSpace(emailError)
+                    ? "Certificate update saved, but the email notification could not be sent."
+                    : $"Certificate update saved, but the email notification could not be sent: {emailError}";
+                TempData[CertificateActionErrorKey] = errorMessage;
+            }
         }
         catch (DbUpdateException)
         {
@@ -324,20 +388,53 @@ public sealed class HrDashboardController : Controller
         return await _db.Users.FindAsync(id);
     }
 
+    private async Task<(bool ok, string? error)> SendEmployeeLeaveEmailAsync(
+        LeaveRequest request,
+        string subject,
+        string introParagraph,
+        string? additionalParagraph = null)
+    {
+        var employee = request.User ?? await _db.Users.FindAsync(request.UserId);
+        if (employee is null || string.IsNullOrWhiteSpace(employee.Email))
+        {
+            return (false, "Employee email address could not be determined.");
+        }
+
+        var typeLabel = FormatLeaveType(request.Type);
+        var reasonHtml = string.IsNullOrWhiteSpace(request.Reason)
+            ? "<em>No reason provided.</em>"
+            : System.Net.WebUtility.HtmlEncode(request.Reason);
+
+        var builder = new StringBuilder();
+        builder.Append($"<p>Hi {System.Net.WebUtility.HtmlEncode(employee.Name)},</p>");
+        builder.Append($"<p>{introParagraph}</p>");
+
+        if (!string.IsNullOrWhiteSpace(additionalParagraph))
+        {
+            builder.Append($"<p>{additionalParagraph}</p>");
+        }
+
+        builder.Append("<p><strong>Leave details:</strong><br/>");
+        builder.Append($"Type: {System.Net.WebUtility.HtmlEncode(typeLabel)}<br/>");
+        builder.Append($"Dates: {request.StartDate:MMM d, yyyy} – {request.EndDate:MMM d, yyyy}<br/>");
+        builder.Append($"Total days: {request.TotalDays}<br/>");
+        builder.Append($"Reason: {reasonHtml}</p>");
+
+        var dashboardUrl = Url.Action("Index", "EmployeeDashboard", values: null, protocol: Request.Scheme, host: Request.Host.Value);
+        if (!string.IsNullOrWhiteSpace(dashboardUrl))
+        {
+            builder.Append($"<p>View your leave requests: <a href=\"{dashboardUrl}\">{dashboardUrl}</a></p>");
+        }
+
+        builder.Append("<p>— TrackHive</p>");
+
+        return await _email.SendAsync(employee.Email, subject, builder.ToString());
+    }
 
     private async Task<HrDashboardViewModel> BuildDashboardViewModelAsync(AppUser hr, InviteEmployeeViewModel? inviteOverride)
     {
         var org = await _db.Organizations.AsNoTracking().FirstOrDefaultAsync(o => o.Id == hr.OrganizationId);
         var invite = inviteOverride ?? new InviteEmployeeViewModel();
-
-        static string FormatLeaveType(LeaveType type) => type switch
-        {
-            LeaveType.Annual => "Annual leave",
-            LeaveType.Sick => "Sick leave",
-            LeaveType.Emergency => "Emergency leave",
-            LeaveType.Unpaid => "Unpaid leave",
-            _ => "Other leave"
-        };
 
         var employees = await _db.Users
             .AsNoTracking()


### PR DESCRIPTION
## Summary
- send HR email alerts whenever employees submit leave requests or medical certificates
- notify employees by email when HR approves or rejects leave requests and certificate reviews
- add reusable helpers for formatting leave details and dispatching notification emails

## Testing
- `dotnet build` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68caa5c5b36c83289e0914e00eadc427