### PR TITLE
Add plan-based gating for payroll and analytics features

### DIFF
--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -250,6 +250,7 @@ public sealed class AuthController : Controller
         {
             Name = orgName,
             CreatedByEmail = model.Email.Trim(),
+            Plan = OrganizationPlan.Free,
             CreatedAt = DateTime.UtcNow
         };
         _db.Organizations.Add(org);

--- a/Controllers/HrDashboardController.cs
+++ b/Controllers/HrDashboardController.cs
@@ -435,6 +435,8 @@ public sealed class HrDashboardController : Controller
     {
         var org = await _db.Organizations.AsNoTracking().FirstOrDefaultAsync(o => o.Id == hr.OrganizationId);
         var invite = inviteOverride ?? new InviteEmployeeViewModel();
+        var plan = org?.Plan ?? OrganizationPlan.Free;
+        var canViewAnalytics = PlanHelper.CanViewAnalytics(plan);
 
         var employees = await _db.Users
             .AsNoTracking()
@@ -713,98 +715,107 @@ public sealed class HrDashboardController : Controller
             .Take(10)
             .ToList();
 
-        var currentMonthUtc = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1, 0, 0, 0, DateTimeKind.Utc);
-        var monthRange = Enumerable.Range(0, 6)
-            .Select(offset => currentMonthUtc.AddMonths(offset - 5))
-            .Select(date => new
-            {
-                Date = date,
-                Label = date.ToString("MMM yyyy", CultureInfo.InvariantCulture)
-            })
-            .ToList();
-
-        var monthlyTrends = new List<MonthlyLeaveTrendViewModel>();
-        var leaveTypeBreakdown = new List<LeaveTypeBreakdownViewModel>();
         var leavesReviewedThisMonth = 0;
+        IReadOnlyList<MonthlyLeaveTrendViewModel> monthlyTrends = Array.Empty<MonthlyLeaveTrendViewModel>();
+        IReadOnlyList<LeaveTypeBreakdownViewModel> leaveTypeBreakdown = Array.Empty<LeaveTypeBreakdownViewModel>();
 
-        if (employeeIds.Count > 0)
+        if (canViewAnalytics)
         {
-            var earliestMonth = monthRange.First().Date;
-            var leaveHistory = await _db.LeaveRequests
-                .AsNoTracking()
-                .Where(r => employeeIds.Contains(r.UserId) && r.CreatedAt >= earliestMonth)
-                .Select(r => new { r.CreatedAt, r.Status })
-                .ToListAsync();
-
-            var monthlyLookup = leaveHistory
-                .GroupBy(r => new DateTime(r.CreatedAt.Year, r.CreatedAt.Month, 1, 0, 0, 0, DateTimeKind.Utc))
-                .ToDictionary(
-                    g => g.Key,
-                    g =>
-                    {
-                        var pending = g.Count(x => x.Status == LeaveRequestStatus.Pending || x.Status == LeaveRequestStatus.AwaitingCertificateReview);
-                        var approved = g.Count(x => x.Status == LeaveRequestStatus.Approved || x.Status == LeaveRequestStatus.ApprovedAwaitingCertificate);
-                        var rejected = g.Count(x => x.Status == LeaveRequestStatus.Rejected || x.Status == LeaveRequestStatus.CertificateRejected);
-                        return (Pending: pending, Approved: approved, Rejected: rejected);
-                    });
-
-            foreach (var info in monthRange)
-            {
-                if (monthlyLookup.TryGetValue(info.Date, out var counts))
+            var currentMonthUtc = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+            var monthRange = Enumerable.Range(0, 6)
+                .Select(offset => currentMonthUtc.AddMonths(offset - 5))
+                .Select(date => new
                 {
-                    monthlyTrends.Add(new MonthlyLeaveTrendViewModel
-                    {
-                        MonthLabel = info.Label,
-                        Pending = counts.Pending,
-                        Approved = counts.Approved,
-                        Rejected = counts.Rejected
-                    });
+                    Date = date,
+                    Label = date.ToString("MMM yyyy", CultureInfo.InvariantCulture)
+                })
+                .ToList();
 
-                    if (info.Date == currentMonthUtc)
+            var trendList = new List<MonthlyLeaveTrendViewModel>();
+            var breakdownList = new List<LeaveTypeBreakdownViewModel>();
+
+            if (employeeIds.Count > 0)
+            {
+                var earliestMonth = monthRange.First().Date;
+                var leaveHistory = await _db.LeaveRequests
+                    .AsNoTracking()
+                    .Where(r => employeeIds.Contains(r.UserId) && r.CreatedAt >= earliestMonth)
+                    .Select(r => new { r.CreatedAt, r.Status })
+                    .ToListAsync();
+
+                var monthlyLookup = leaveHistory
+                    .GroupBy(r => new DateTime(r.CreatedAt.Year, r.CreatedAt.Month, 1, 0, 0, 0, DateTimeKind.Utc))
+                    .ToDictionary(
+                        g => g.Key,
+                        g =>
+                        {
+                            var pending = g.Count(x => x.Status == LeaveRequestStatus.Pending || x.Status == LeaveRequestStatus.AwaitingCertificateReview);
+                            var approved = g.Count(x => x.Status == LeaveRequestStatus.Approved || x.Status == LeaveRequestStatus.ApprovedAwaitingCertificate);
+                            var rejected = g.Count(x => x.Status == LeaveRequestStatus.Rejected || x.Status == LeaveRequestStatus.CertificateRejected);
+                            return (Pending: pending, Approved: approved, Rejected: rejected);
+                        });
+
+                foreach (var info in monthRange)
+                {
+                    if (monthlyLookup.TryGetValue(info.Date, out var counts))
                     {
-                        leavesReviewedThisMonth = counts.Approved + counts.Rejected;
+                        trendList.Add(new MonthlyLeaveTrendViewModel
+                        {
+                            MonthLabel = info.Label,
+                            Pending = counts.Pending,
+                            Approved = counts.Approved,
+                            Rejected = counts.Rejected
+                        });
+
+                        if (info.Date == currentMonthUtc)
+                        {
+                            leavesReviewedThisMonth = counts.Approved + counts.Rejected;
+                        }
+                    }
+                    else
+                    {
+                        trendList.Add(new MonthlyLeaveTrendViewModel
+                        {
+                            MonthLabel = info.Label,
+                            Pending = 0,
+                            Approved = 0,
+                            Rejected = 0
+                        });
                     }
                 }
-                else
-                {
-                    monthlyTrends.Add(new MonthlyLeaveTrendViewModel
+
+                var typeCounts = await _db.LeaveRequests
+                    .AsNoTracking()
+                    .Where(r => employeeIds.Contains(r.UserId))
+                    .GroupBy(r => r.Type)
+                    .Select(g => new { Type = g.Key, Count = g.Count() })
+                    .ToListAsync();
+
+                breakdownList = typeCounts
+                    .OrderByDescending(t => t.Count)
+                    .Select(t => new LeaveTypeBreakdownViewModel
+                    {
+                        Type = FormatLeaveType(t.Type),
+                        Count = t.Count
+                    })
+                    .ToList();
+            }
+
+            if (trendList.Count == 0)
+            {
+                trendList = monthRange
+                    .Select(info => new MonthlyLeaveTrendViewModel
                     {
                         MonthLabel = info.Label,
                         Pending = 0,
                         Approved = 0,
                         Rejected = 0
-                    });
-                }
+                    })
+                    .ToList();
             }
 
-            var typeCounts = await _db.LeaveRequests
-                .AsNoTracking()
-                .Where(r => employeeIds.Contains(r.UserId))
-                .GroupBy(r => r.Type)
-                .Select(g => new { Type = g.Key, Count = g.Count() })
-                .ToListAsync();
-
-            leaveTypeBreakdown = typeCounts
-                .OrderByDescending(t => t.Count)
-                .Select(t => new LeaveTypeBreakdownViewModel
-                {
-                    Type = FormatLeaveType(t.Type),
-                    Count = t.Count
-                })
-                .ToList();
-        }
-
-        if (monthlyTrends.Count == 0)
-        {
-            monthlyTrends = monthRange
-                .Select(info => new MonthlyLeaveTrendViewModel
-                {
-                    MonthLabel = info.Label,
-                    Pending = 0,
-                    Approved = 0,
-                    Rejected = 0
-                })
-                .ToList();
+            monthlyTrends = trendList;
+            leaveTypeBreakdown = breakdownList;
         }
 
         var metrics = new DashboardMetricsViewModel
@@ -826,7 +837,9 @@ public sealed class HrDashboardController : Controller
             PendingCertificateRequests = certificateViewModels,
             LeaveSummaries = leaveSummaries,
             Notifications = orderedNotifications,
-            Metrics = metrics
+            Metrics = metrics,
+            Plan = plan,
+            CanViewAnalytics = canViewAnalytics
         };
     }
 

--- a/Controllers/PayrollController.cs
+++ b/Controllers/PayrollController.cs
@@ -31,7 +31,9 @@ public sealed class PayrollController : Controller
         if (hr is null) return RedirectToAction("Login", "Auth");
         if (hr.MustChangePassword) return RedirectToAction("ChangePassword", "Auth");
 
-        var employees = await LoadEmployeesAsync(hr.OrganizationId);
+        var plan = await GetOrganizationPlanAsync(hr.OrganizationId);
+        var canUsePayroll = PlanHelper.CanAccessPayroll(plan);
+        var canExportPdf = PlanHelper.CanExportPdf(plan);
         var now = DateTime.UtcNow;
         var form = new PayrollCalculationForm
         {
@@ -41,6 +43,21 @@ public sealed class PayrollController : Controller
             ManualDeductions = 0m,
             AdditionalOvertimeHours = 0m
         };
+
+        if (!canUsePayroll)
+        {
+            var restrictedModel = new PayrollIndexViewModel
+            {
+                Plan = plan,
+                CanUsePayroll = false,
+                CanExportPdf = canExportPdf,
+                Form = form
+            };
+
+            return View(restrictedModel);
+        }
+
+        var employees = await LoadEmployeesAsync(hr.OrganizationId);
 
         PayrollCalculationResult? result = null;
         IReadOnlyList<PastPayrollRecordViewModel> history = Array.Empty<PastPayrollRecordViewModel>();
@@ -67,7 +84,10 @@ public sealed class PayrollController : Controller
             Result = result,
             History = history,
             AlertMessage = alertMessage,
-            AlertType = alertType
+            AlertType = alertType,
+            Plan = plan,
+            CanUsePayroll = true,
+            CanExportPdf = canExportPdf
         };
 
         return View(viewModel);
@@ -83,6 +103,23 @@ public sealed class PayrollController : Controller
 
         var form = postedModel.Form ?? new PayrollCalculationForm();
         postedModel.Form = form;
+        var plan = await GetOrganizationPlanAsync(hr.OrganizationId);
+        var canUsePayroll = PlanHelper.CanAccessPayroll(plan);
+        var canExportPdf = PlanHelper.CanExportPdf(plan);
+
+        if (!canUsePayroll)
+        {
+            var restrictedModel = new PayrollIndexViewModel
+            {
+                Plan = plan,
+                CanUsePayroll = false,
+                CanExportPdf = canExportPdf,
+                Form = form
+            };
+
+            return View("Index", restrictedModel);
+        }
+
         var employees = await LoadEmployeesAsync(hr.OrganizationId);
         PayrollCalculationResult? result = null;
         IReadOnlyList<PastPayrollRecordViewModel> history = Array.Empty<PastPayrollRecordViewModel>();
@@ -157,7 +194,10 @@ public sealed class PayrollController : Controller
             Result = result,
             History = history,
             AlertMessage = alertMessage,
-            AlertType = alertType
+            AlertType = alertType,
+            Plan = plan,
+            CanUsePayroll = true,
+            CanExportPdf = canExportPdf
         };
 
         return View("Index", viewModel);
@@ -170,6 +210,23 @@ public sealed class PayrollController : Controller
         if (hr is null) return RedirectToAction("Login", "Auth");
         if (hr.MustChangePassword) return RedirectToAction("ChangePassword", "Auth");
 
+        var plan = await GetOrganizationPlanAsync(hr.OrganizationId);
+        var canUsePayroll = PlanHelper.CanAccessPayroll(plan);
+        var canExportPdf = PlanHelper.CanExportPdf(plan);
+        var routeValues = new { employeeId, year, month };
+
+        if (!canUsePayroll)
+        {
+            SetTempAlert($"Upgrade to the {PlanHelper.GetDisplayName(PlanHelper.PayrollRequiredPlan)} plan to manage payroll.", "info");
+            return RedirectToAction("Index", routeValues);
+        }
+
+        if (!canExportPdf)
+        {
+            SetTempAlert($"PDF exports are available on the {PlanHelper.GetDisplayName(PlanHelper.PdfRequiredPlan)} plan.", "info");
+            return RedirectToAction("Index", routeValues);
+        }
+
         var form = new PayrollCalculationForm
         {
             SelectedEmployeeId = employeeId,
@@ -178,8 +235,6 @@ public sealed class PayrollController : Controller
             ManualDeductions = 0m,
             AdditionalOvertimeHours = 0m
         };
-
-        var routeValues = new { employeeId, year, month };
 
         var result = await TryCreatePayslipAsync(hr, form, allowRecalculation: false);
         if (result.Document is null)
@@ -203,7 +258,22 @@ public sealed class PayrollController : Controller
         if (hr is null) return RedirectToAction("Login", "Auth");
         if (hr.MustChangePassword) return RedirectToAction("ChangePassword", "Auth");
 
+        var plan = await GetOrganizationPlanAsync(hr.OrganizationId);
+        var canUsePayroll = PlanHelper.CanAccessPayroll(plan);
+        var canExportPdf = PlanHelper.CanExportPdf(plan);
         var routeValues = new { employeeId = form.SelectedEmployeeId, year = form.Year, month = form.Month };
+
+        if (!canUsePayroll)
+        {
+            SetTempAlert($"Upgrade to the {PlanHelper.GetDisplayName(PlanHelper.PayrollRequiredPlan)} plan to manage payroll.", "info");
+            return RedirectToAction("Index", routeValues);
+        }
+
+        if (!canExportPdf)
+        {
+            SetTempAlert($"PDF exports are available on the {PlanHelper.GetDisplayName(PlanHelper.PdfRequiredPlan)} plan.", "info");
+            return RedirectToAction("Index", routeValues);
+        }
 
         var result = await TryCreatePayslipAsync(hr, form, allowRecalculation: true);
         if (result.Document is null)
@@ -225,6 +295,22 @@ public sealed class PayrollController : Controller
         var hr = await GetCurrentUserAsync();
         if (hr is null) return RedirectToAction("Login", "Auth");
         if (hr.MustChangePassword) return RedirectToAction("ChangePassword", "Auth");
+
+        var plan = await GetOrganizationPlanAsync(hr.OrganizationId);
+        var canUsePayroll = PlanHelper.CanAccessPayroll(plan);
+        var canExportPdf = PlanHelper.CanExportPdf(plan);
+
+        if (!canUsePayroll)
+        {
+            SetTempAlert($"Upgrade to the {PlanHelper.GetDisplayName(PlanHelper.PayrollRequiredPlan)} plan to manage payroll.", "info");
+            return RedirectToAction("Index", new { year, month });
+        }
+
+        if (!canExportPdf)
+        {
+            SetTempAlert($"PDF exports are available on the {PlanHelper.GetDisplayName(PlanHelper.PdfRequiredPlan)} plan.", "info");
+            return RedirectToAction("Index", new { year, month });
+        }
 
         if (year < 2000 || year > 2100 || month < 1 || month > 12)
         {
@@ -423,6 +509,15 @@ public sealed class PayrollController : Controller
     }
 
     private sealed record PayslipGenerationResult(PayslipDocumentModel? Document, string? ErrorMessage, string AlertType);
+
+    private async Task<OrganizationPlan> GetOrganizationPlanAsync(int organizationId)
+    {
+        return await _db.Organizations
+            .AsNoTracking()
+            .Where(o => o.Id == organizationId)
+            .Select(o => o.Plan)
+            .FirstOrDefaultAsync();
+    }
 
     private async Task<AppUser?> GetCurrentUserAsync()
     {

--- a/Models/20251215093000_OrganizationPlans.Designer.cs
+++ b/Models/20251215093000_OrganizationPlans.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TrackHive.Models;
 
@@ -11,9 +12,10 @@ using TrackHive.Models;
 namespace TrackHive.Models
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251215093000_OrganizationPlans")]
+    partial class OrganizationPlans
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Models/20251215093000_OrganizationPlans.cs
+++ b/Models/20251215093000_OrganizationPlans.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TrackHive.Models
+{
+    /// <inheritdoc />
+    public partial class OrganizationPlans : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Plan",
+                table: "Organizations",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Plan",
+                table: "Organizations");
+        }
+    }
+}

--- a/Models/AppDbContext.cs
+++ b/Models/AppDbContext.cs
@@ -21,6 +21,10 @@ public sealed class AppDbContext : DbContext
     {
 
 
+        modelBuilder.Entity<Organization>()
+            .Property(o => o.Plan)
+            .HasDefaultValue(OrganizationPlan.Free);
+
         modelBuilder.Entity<AppUser>()
             .Property(u => u.BirthDate)
             .HasColumnType("date");

--- a/Models/HrDashboardViewModel.cs
+++ b/Models/HrDashboardViewModel.cs
@@ -9,6 +9,8 @@ public sealed class HrDashboardViewModel
     public IReadOnlyList<LeaveBalanceSummaryViewModel> LeaveSummaries { get; init; } = Array.Empty<LeaveBalanceSummaryViewModel>();
     public IReadOnlyList<DashboardNotificationViewModel> Notifications { get; init; } = Array.Empty<DashboardNotificationViewModel>();
     public DashboardMetricsViewModel Metrics { get; init; } = new();
+    public OrganizationPlan Plan { get; init; } = OrganizationPlan.Free;
+    public bool CanViewAnalytics { get; init; }
 }
 
 public sealed class LeaveRequestReviewViewModel

--- a/Models/Organization.cs
+++ b/Models/Organization.cs
@@ -13,5 +13,8 @@ public sealed class Organization
     [Required, EmailAddress]
     public string CreatedByEmail { get; set; } = string.Empty;
 
+    [Required]
+    public OrganizationPlan Plan { get; set; } = OrganizationPlan.Free;
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/Models/OrganizationPlan.cs
+++ b/Models/OrganizationPlan.cs
@@ -1,0 +1,9 @@
+namespace TrackHive.Models;
+
+public enum OrganizationPlan
+{
+    Free = 0,
+    Starter = 1,
+    Growth = 2,
+    Scale = 3
+}

--- a/Models/PayrollViewModels.cs
+++ b/Models/PayrollViewModels.cs
@@ -88,4 +88,7 @@ public sealed class PayrollIndexViewModel
     public string AlertType { get; init; } = "info";
 
     public bool HasEmployees => Employees.Count > 0;
+    public OrganizationPlan Plan { get; init; } = OrganizationPlan.Free;
+    public bool CanUsePayroll { get; init; } = true;
+    public bool CanExportPdf { get; init; } = true;
 }

--- a/Models/PlanHelper.cs
+++ b/Models/PlanHelper.cs
@@ -1,0 +1,25 @@
+namespace TrackHive.Models;
+
+public static class PlanHelper
+{
+    public const OrganizationPlan PayrollRequiredPlan = OrganizationPlan.Growth;
+    public const OrganizationPlan AnalyticsRequiredPlan = OrganizationPlan.Growth;
+    public const OrganizationPlan PdfRequiredPlan = OrganizationPlan.Starter;
+
+    public static bool CanAccessPayroll(OrganizationPlan plan) => plan >= PayrollRequiredPlan;
+
+    public static bool CanViewAnalytics(OrganizationPlan plan) => plan >= AnalyticsRequiredPlan;
+
+    public static bool CanExportPdf(OrganizationPlan plan) => plan >= PdfRequiredPlan;
+
+    public static bool RequiresUpgrade(OrganizationPlan plan, OrganizationPlan required) => plan < required;
+
+    public static string GetDisplayName(OrganizationPlan plan) => plan switch
+    {
+        OrganizationPlan.Free => "Free",
+        OrganizationPlan.Starter => "Starter",
+        OrganizationPlan.Growth => "Growth",
+        OrganizationPlan.Scale => "Scale",
+        _ => plan.ToString()
+    };
+}

--- a/Views/HrDashboard/Index.cshtml
+++ b/Views/HrDashboard/Index.cshtml
@@ -29,6 +29,8 @@
         LeaveType.Unpaid => "Unpaid leave",
         _ => "Other leave"
     };
+    var analyticsRequiredPlan = PlanHelper.GetDisplayName(PlanHelper.AnalyticsRequiredPlan);
+    var currentPlanName = PlanHelper.GetDisplayName(Model.Plan);
 }
 <div class="row">
     <div class="col-12 col-xl-8">
@@ -39,43 +41,56 @@
             </div>
         </div>
 
-        <div class="row g-3 mt-4 align-items-stretch">
-            <!-- Left: Leave decisions by month -->
-            <div class="col-12 col-lg-8">
-                <div class="border rounded-3 p-3 h-100">
-                    <div class="d-flex justify-content-between align-items-center mb-2">
-                        <h3 class="h6 mb-0">Leave decisions by month</h3>
-                        <span class="text-secondary small">Past six months</span>
-                    </div>
-                    <div class="ratio ratio-16x9 bg-body-tertiary rounded-3">
-                        <canvas id="leaveTrendChart" role="img"
-                                aria-label="Line chart showing leave decisions by month"></canvas>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Right: Leave type distribution -->
-            <div class="col-12 col-lg-4">
-                <div class="border rounded-3 p-3 h-100">
-                    <div class="d-flex justify-content-between align-items-center mb-2">
-                        <h3 class="h6 mb-0">Leave type distribution</h3>
-                        <span class="text-secondary small">All recorded requests</span>
-                    </div>
-
-                    @if (metrics.LeaveTypeBreakdown.Count == 0)
-                    {
-                        <p class="text-secondary small mb-0">No leave requests have been recorded yet.</p>
-                    }
-                    else
-                    {
-                        <div class="ratio ratio-1x1 bg-body-tertiary rounded-3">
-                            <canvas id="leaveTypeChart" role="img"
-                                    aria-label="Doughnut chart showing leave type distribution"></canvas>
+        @if (Model.CanViewAnalytics)
+        {
+            <div class="card shadow-sm mb-4 mt-4" id="hrMetricsCard">
+                <div class="card-body p-4">
+                    <div class="row g-3 align-items-stretch">
+                        <div class="col-12 col-lg-8">
+                            <div class="border rounded-3 p-3 h-100">
+                                <div class="d-flex justify-content-between align-items-center mb-2">
+                                    <h3 class="h6 mb-0">Leave decisions by month</h3>
+                                    <span class="text-secondary small">Past six months</span>
+                                </div>
+                                <div class="ratio ratio-16x9 bg-body-tertiary rounded-3">
+                                    <canvas id="leaveTrendChart" role="img"
+                                            aria-label="Line chart showing leave decisions by month"></canvas>
+                                </div>
+                            </div>
                         </div>
-                    }
+                        <div class="col-12 col-lg-4">
+                            <div class="border rounded-3 p-3 h-100">
+                                <div class="d-flex justify-content-between align-items-center mb-2">
+                                    <h3 class="h6 mb-0">Leave type distribution</h3>
+                                    <span class="text-secondary small">All recorded requests</span>
+                                </div>
+
+                                @if (metrics.LeaveTypeBreakdown.Count == 0)
+                                {
+                                    <p class="text-secondary small mb-0">No leave requests have been recorded yet.</p>
+                                }
+                                else
+                                {
+                                    <div class="ratio ratio-1x1 bg-body-tertiary rounded-3">
+                                        <canvas id="leaveTypeChart" role="img"
+                                                aria-label="Doughnut chart showing leave type distribution"></canvas>
+                                    </div>
+                                }
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
+        }
+        else
+        {
+            <div class="card shadow-sm mb-4 mt-4">
+                <div class="card-body p-5">
+                    <h2 class="h5 mb-2">Upgrade to unlock HR analytics</h2>
+                    <p class="text-secondary mb-0">Your organization is on the <strong>@currentPlanName</strong> plan. Charts and metrics are available on the <strong>@analyticsRequiredPlan</strong> plan and above.</p>
+                </div>
+            </div>
+        }
 
 
         <div class="card shadow-sm mb-4">

--- a/Views/Payroll/Index.cshtml
+++ b/Views/Payroll/Index.cshtml
@@ -9,8 +9,29 @@
     var invariant = System.Globalization.CultureInfo.InvariantCulture;
     bool HasSavedRecord(TrackHive.Models.PayrollCalculationResult value) =>
         Model.History.Any(h => h.Year == value.Year && h.Month == value.Month);
+    var currentPlanName = PlanHelper.GetDisplayName(Model.Plan);
+    var payrollRequiredPlan = PlanHelper.GetDisplayName(PlanHelper.PayrollRequiredPlan);
+    var exportRequiredPlan = PlanHelper.GetDisplayName(PlanHelper.PdfRequiredPlan);
 }
 
+@if (!Model.CanUsePayroll)
+{
+    <div class="row g-4">
+        <div class="col-12 col-xl-8">
+            <div class="card shadow-sm mb-4">
+                <div class="card-body p-5">
+                    <h1 class="h4 mb-3">Upgrade to unlock payroll</h1>
+                    <p class="text-secondary mb-3">
+                        Your organization is on the <strong>@currentPlanName</strong> plan. Payroll is available on the <strong>@payrollRequiredPlan</strong> plan and above.
+                    </p>
+                    <p class="text-secondary mb-0">Contact your TrackHive representative to upgrade and start calculating pay, storing history, and generating payslips.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+else
+{
 <div class="row g-4">
     <div class="col-12 col-xl-7">
         <div class="card shadow-sm mb-4">
@@ -30,6 +51,13 @@
                 }
                 else
                 {
+                    if (!Model.CanExportPdf)
+                    {
+                        <div class="alert alert-info mb-3" role="alert">
+                            PDF exports are available on the <strong>@exportRequiredPlan</strong> plan.
+                        </div>
+                    }
+
                     if (!string.IsNullOrWhiteSpace(Model.AlertMessage))
                     {
                         <div class="alert alert-@Model.AlertType" role="alert">@Model.AlertMessage</div>
@@ -134,18 +162,25 @@
 
                     @{ var hasSavedRecord = HasSavedRecord(result); }
                     <div class="d-flex flex-wrap gap-2 align-items-center mb-4">
-                        <form asp-action="DownloadPayslip" asp-controller="Payroll" method="post" class="d-inline">
-                            @Html.AntiForgeryToken()
-                            <input type="hidden" name="SelectedEmployeeId" value="@result.EmployeeId" />
-                            <input type="hidden" name="Year" value="@Model.Form.Year" />
-                            <input type="hidden" name="Month" value="@Model.Form.Month" />
-                            <input type="hidden" name="ManualDeductions" value="@Model.Form.ManualDeductions.ToString(invariant)" />
-                            <input type="hidden" name="AdditionalOvertimeHours" value="@Model.Form.AdditionalOvertimeHours.ToString(invariant)" />
-                            <button type="submit" class="btn btn-outline-primary">Download payslip (PDF)</button>
-                        </form>
-                        <span class="text-secondary small">
-                            @(hasSavedRecord ? "Uses the stored payroll record for this period." : "Exports the current calculation if no saved record exists.")
-                        </span>
+                        @if (Model.CanExportPdf)
+                        {
+                            <form asp-action="DownloadPayslip" asp-controller="Payroll" method="post" class="d-inline">
+                                @Html.AntiForgeryToken()
+                                <input type="hidden" name="SelectedEmployeeId" value="@result.EmployeeId" />
+                                <input type="hidden" name="Year" value="@Model.Form.Year" />
+                                <input type="hidden" name="Month" value="@Model.Form.Month" />
+                                <input type="hidden" name="ManualDeductions" value="@Model.Form.ManualDeductions.ToString(invariant)" />
+                                <input type="hidden" name="AdditionalOvertimeHours" value="@Model.Form.AdditionalOvertimeHours.ToString(invariant)" />
+                                <button type="submit" class="btn btn-outline-primary">Download payslip (PDF)</button>
+                            </form>
+                            <span class="text-secondary small">
+                                @(hasSavedRecord ? "Uses the stored payroll record for this period." : "Exports the current calculation if no saved record exists.")
+                            </span>
+                        }
+                        else
+                        {
+                            <span class="text-secondary small">Upgrade to the @exportRequiredPlan plan to export payslips.</span>
+                        }
                     </div>
 
                     <div class="table-responsive mb-4">
@@ -232,11 +267,18 @@
             <div class="card-body p-4">
                 <div class="d-flex justify-content-between align-items-center mb-3">
                     <h2 class="h6 mb-0">Recent payroll history</h2>
-                    <a class="btn btn-sm btn-outline-secondary"
-                       asp-action="DownloadReport"
-                       asp-controller="Payroll"
-                       asp-route-year="@Model.Form.Year"
-                       asp-route-month="@Model.Form.Month">Export report (PDF)</a>
+                    @if (Model.CanExportPdf)
+                    {
+                        <a class="btn btn-sm btn-outline-secondary"
+                           asp-action="DownloadReport"
+                           asp-controller="Payroll"
+                           asp-route-year="@Model.Form.Year"
+                           asp-route-month="@Model.Form.Month">Export report (PDF)</a>
+                    }
+                    else
+                    {
+                        <span class="text-secondary small">Upgrade to the @exportRequiredPlan plan to export monthly reports.</span>
+                    }
                 </div>
                 @if (Model.History.Count == 0)
                 {
@@ -267,7 +309,7 @@
                                         <td class="text-end text-secondary">@string.Format("${0:N2}", record.GrossPay)</td>
                                         <td class="text-end text-danger">@string.Format("${0:N2}", record.Deductions)</td>
                                         <td class="text-end">
-                                            @if (Model.Form.SelectedEmployeeId.HasValue)
+                                            @if (Model.CanExportPdf && Model.Form.SelectedEmployeeId.HasValue)
                                             {
                                                 <a class="btn btn-sm btn-outline-secondary"
                                                    asp-action="DownloadPayslip"
@@ -276,9 +318,13 @@
                                                    asp-route-year="@record.Year"
                                                    asp-route-month="@record.Month">Payslip</a>
                                             }
-                                            else
+                                            else if (Model.CanExportPdf)
                                             {
                                                 <span class="text-secondary">—</span>
+                                            }
+                                            else
+                                            {
+                                                <span class="text-secondary small">Upgrade for PDFs</span>
                                             }
                                         </td>
                                     </tr>
@@ -291,5 +337,5 @@
         </div>
     </div>
 </div>
-
+}
 


### PR DESCRIPTION
## Summary
- introduce an organization plan enum, helper utilities, and a migration so plan-aware feature checks can be centralized
- guard payroll and HR analytics controllers/views with plan checks that show upgrade prompts when access is restricted
- hide payroll PDF export actions for free plans and surface upgrade messaging in the UI

## Testing
- `dotnet build` *(fails: .NET SDK is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d39f2f7a68832885860c24bfebf943