### PR TITLE
Add Stripe billing integration

### DIFF
--- a/Controllers/BillingController.cs
+++ b/Controllers/BillingController.cs
@@ -1,0 +1,451 @@
+// File: Controllers/BillingController.cs
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Stripe;
+using Stripe.Checkout;
+using TrackHive.Models;
+using TrackHive.Services;
+
+namespace TrackHive.Controllers;
+
+[Authorize(Roles = "IT")]
+public sealed class BillingController : Controller
+{
+    private readonly AppDbContext _db;
+    private readonly BillingService _billing;
+    private readonly StripeOptions _stripeOptions;
+    private readonly ILogger<BillingController> _logger;
+
+    public BillingController(
+        AppDbContext db,
+        BillingService billing,
+        IOptions<StripeOptions> stripeOptions,
+        ILogger<BillingController> logger)
+    {
+        _db = db;
+        _billing = billing;
+        _stripeOptions = stripeOptions?.Value ?? new StripeOptions();
+        _logger = logger;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Upgrade()
+    {
+        var orgId = GetOrgId();
+        if (orgId <= 0)
+        {
+            TempData["Error"] = "We couldn't determine your organization.";
+            return RedirectToAction("Index", "Dashboard");
+        }
+
+        var org = await _db.Organizations.AsNoTracking().FirstOrDefaultAsync(o => o.Id == orgId);
+        if (org is null)
+        {
+            TempData["Error"] = "Organization not found.";
+            return RedirectToAction("Index", "Dashboard");
+        }
+
+        var plans = new List<BillingPlanOption>
+        {
+            CreatePlanOption(SubscriptionPlan.Starter),
+            CreatePlanOption(SubscriptionPlan.Pro),
+            CreatePlanOption(SubscriptionPlan.Enterprise)
+        };
+
+        var vm = new BillingUpgradeViewModel
+        {
+            CurrentPlan = org.SubscriptionPlan,
+            Plans = plans
+        };
+
+        ViewData["Title"] = "Upgrade plan";
+        ViewData["OrgName"] = org.Name;
+        return View(vm);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> StartCheckout(SubscriptionPlan plan)
+    {
+        if (plan is SubscriptionPlan.Free || plan is not (SubscriptionPlan.Starter or SubscriptionPlan.Pro or SubscriptionPlan.Enterprise))
+        {
+            TempData["Error"] = "Select a paid plan to continue.";
+            return RedirectToAction(nameof(Upgrade));
+        }
+
+        var orgId = GetOrgId();
+        if (orgId <= 0)
+        {
+            TempData["Error"] = "We couldn't determine your organization.";
+            return RedirectToAction(nameof(Upgrade));
+        }
+
+        var org = await _db.Organizations.FindAsync(orgId);
+        if (org is null)
+        {
+            TempData["Error"] = "Organization not found.";
+            return RedirectToAction(nameof(Upgrade));
+        }
+
+        try
+        {
+            var successUrl = Url.Action(nameof(Success), "Billing", values: null, protocol: Request.Scheme, host: Request.Host.ToString());
+            if (string.IsNullOrWhiteSpace(successUrl))
+            {
+                throw new InvalidOperationException("Unable to resolve the success URL.");
+            }
+            successUrl = QueryHelpers.AddQueryString(successUrl, "session_id", "{CHECKOUT_SESSION_ID}");
+
+            var cancelUrl = Url.Action(nameof(Failed), "Billing", new { plan }, Request.Scheme, Request.Host.ToString());
+            if (string.IsNullOrWhiteSpace(cancelUrl))
+            {
+                throw new InvalidOperationException("Unable to resolve the cancel URL.");
+            }
+
+            var email = User.FindFirstValue(ClaimTypes.Email);
+            var session = await _billing.CreateCheckoutSessionAsync(org.Id, plan, email, successUrl, cancelUrl);
+
+            if (string.IsNullOrWhiteSpace(session.Url))
+            {
+                throw new InvalidOperationException("Stripe did not return a checkout URL.");
+            }
+
+            return Redirect(session.Url);
+        }
+        catch (StripeException ex)
+        {
+            _logger.LogError(ex, "Failed to create Stripe checkout session for organization {OrgId}", orgId);
+            TempData["Error"] = "We couldn't start the checkout session. Please try again.";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to start billing upgrade for organization {OrgId}", orgId);
+            TempData["Error"] = "Something went wrong while starting the checkout. Please try again.";
+        }
+
+        return RedirectToAction(nameof(Upgrade));
+    }
+
+    [AllowAnonymous]
+    [IgnoreAntiforgeryToken]
+    [HttpPost]
+    public async Task<IActionResult> Webhook()
+    {
+        if (string.IsNullOrWhiteSpace(_stripeOptions.WebhookSecret))
+        {
+            _logger.LogWarning("Stripe webhook secret is not configured.");
+            return BadRequest();
+        }
+
+        string payload;
+        using (var reader = new StreamReader(Request.Body))
+        {
+            payload = await reader.ReadToEndAsync();
+        }
+
+        var signature = Request.Headers["Stripe-Signature"];
+
+        Event stripeEvent;
+        try
+        {
+            stripeEvent = EventUtility.ConstructEvent(payload, signature, _stripeOptions.WebhookSecret);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to validate Stripe webhook signature.");
+            return BadRequest();
+        }
+
+        try
+        {
+            switch (stripeEvent.Type)
+            {
+                case Events.CheckoutSessionCompleted:
+                    if (stripeEvent.Data.Object is Session checkoutSession)
+                    {
+                        await HandleCheckoutSessionAsync(checkoutSession);
+                    }
+                    break;
+                case Events.CustomerSubscriptionCreated:
+                case Events.CustomerSubscriptionUpdated:
+                    if (stripeEvent.Data.Object is Subscription subscription)
+                    {
+                        await HandleSubscriptionAsync(subscription);
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception while processing Stripe webhook {Event}", stripeEvent.Type);
+            return StatusCode(500);
+        }
+
+        return Ok();
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Success(string session_id)
+    {
+        if (string.IsNullOrWhiteSpace(session_id))
+        {
+            TempData["Error"] = "Missing Stripe checkout session.";
+            return RedirectToAction(nameof(Failed));
+        }
+
+        var session = await _billing.GetSessionAsync(session_id);
+        if (session is null)
+        {
+            TempData["Error"] = "We couldn't verify the payment session.";
+            return RedirectToAction(nameof(Failed));
+        }
+
+        var plan = TryGetPlan(session.Metadata, out var parsedPlan) ? parsedPlan : SubscriptionPlan.Starter;
+
+        var orgId = GetOrgId();
+        var org = await _db.Organizations.AsNoTracking().FirstOrDefaultAsync(o => o.Id == orgId);
+        if (org is not null)
+        {
+            ViewData["OrgName"] = org.Name;
+        }
+
+        DateTime? renewsAt = null;
+        if (session.Subscription is Subscription subscription)
+        {
+            renewsAt = NormalizeToUtc(subscription.CurrentPeriodEnd);
+        }
+
+        var vm = new BillingStatusViewModel
+        {
+            Plan = plan,
+            Success = true,
+            Title = $"{plan.GetDisplayName()} plan activated",
+            Message = plan.GetTagline(),
+            RenewsAt = renewsAt
+        };
+
+        ViewData["Title"] = "Payment successful";
+        return View(vm);
+    }
+
+    [HttpGet]
+    public IActionResult Failed(SubscriptionPlan? plan = null)
+    {
+        var targetPlan = plan is SubscriptionPlan.Free or null ? SubscriptionPlan.Starter : plan!.Value;
+
+        var vm = new BillingStatusViewModel
+        {
+            Plan = targetPlan,
+            Success = false,
+            Title = "Checkout canceled",
+            Message = $"Your {targetPlan.GetDisplayName()} upgrade wasn't completed. No charges were made.",
+            RenewsAt = null
+        };
+
+        ViewData["Title"] = "Payment canceled";
+        return View(vm);
+    }
+
+    private static BillingPlanOption CreatePlanOption(SubscriptionPlan plan) => new()
+    {
+        Plan = plan,
+        Title = plan.GetDisplayName(),
+        Price = plan.GetPriceLabel(),
+        Tagline = plan.GetTagline(),
+        Highlights = plan.GetHighlights()
+    };
+
+    private async Task HandleCheckoutSessionAsync(Session session)
+    {
+        if (!TryGetOrganizationId(session.Metadata, out var orgId))
+        {
+            _logger.LogWarning("Checkout session {SessionId} missing organization metadata.", session.Id);
+            return;
+        }
+
+        Subscription? subscription = null;
+        var subscriptionId = session.SubscriptionId ?? (session.Subscription as Subscription)?.Id;
+        if (!string.IsNullOrWhiteSpace(subscriptionId))
+        {
+            subscription = await _billing.GetSubscriptionAsync(subscriptionId);
+        }
+
+        var plan = TryGetPlan(session.Metadata, out var parsedPlan)
+            ? parsedPlan
+            : ResolvePlanFromSubscription(subscription, SubscriptionPlan.Starter);
+
+        await UpdateOrganizationSubscriptionAsync(
+            orgId,
+            plan,
+            session.CustomerId,
+            subscription?.Id ?? subscriptionId,
+            subscription?.CurrentPeriodEnd);
+    }
+
+    private async Task HandleSubscriptionAsync(Subscription subscription)
+    {
+        if (!TryGetOrganizationId(subscription.Metadata, out var orgId))
+        {
+            _logger.LogWarning("Subscription {SubscriptionId} missing organization metadata.", subscription.Id);
+            return;
+        }
+
+        var plan = TryGetPlan(subscription.Metadata, out var parsedPlan)
+            ? parsedPlan
+            : ResolvePlanFromSubscription(subscription, SubscriptionPlan.Starter);
+
+        await UpdateOrganizationSubscriptionAsync(
+            orgId,
+            plan,
+            subscription.CustomerId,
+            subscription.Id,
+            subscription.CurrentPeriodEnd);
+    }
+
+    private async Task UpdateOrganizationSubscriptionAsync(
+        int organizationId,
+        SubscriptionPlan plan,
+        string? customerId,
+        string? subscriptionId,
+        DateTime? renewsAt)
+    {
+        var org = await _db.Organizations.FirstOrDefaultAsync(o => o.Id == organizationId);
+        if (org is null)
+        {
+            _logger.LogWarning("Organization {OrgId} not found while processing Stripe webhook.", organizationId);
+            return;
+        }
+
+        org.SubscriptionPlan = plan;
+        if (!string.IsNullOrWhiteSpace(customerId))
+        {
+            org.StripeCustomerId = customerId;
+        }
+
+        if (!string.IsNullOrWhiteSpace(subscriptionId))
+        {
+            org.StripeSubscriptionId = subscriptionId;
+        }
+
+        org.SubscriptionRenewsAt = NormalizeToUtc(renewsAt);
+        org.SubscriptionUpdatedAt = DateTime.UtcNow;
+
+        await _db.SaveChangesAsync();
+    }
+
+    private bool TryGetOrganizationId(IReadOnlyDictionary<string, string> metadata, out int organizationId)
+    {
+        organizationId = 0;
+        if (metadata is null)
+        {
+            return false;
+        }
+
+        if (metadata.TryGetValue("organizationId", out var value) &&
+            int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+        {
+            organizationId = parsed;
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TryGetPlan(IReadOnlyDictionary<string, string> metadata, out SubscriptionPlan plan)
+    {
+        plan = SubscriptionPlan.Free;
+        if (metadata is null)
+        {
+            return false;
+        }
+
+        if (metadata.TryGetValue("plan", out var value) &&
+            Enum.TryParse(value, true, out SubscriptionPlan parsed) &&
+            parsed is SubscriptionPlan.Starter or SubscriptionPlan.Pro or SubscriptionPlan.Enterprise)
+        {
+            plan = parsed;
+            return true;
+        }
+
+        return false;
+    }
+
+    private SubscriptionPlan ResolvePlanFromSubscription(Subscription? subscription, SubscriptionPlan fallback)
+    {
+        if (subscription is null)
+        {
+            return fallback;
+        }
+
+        var priceId = subscription.Items?.Data?.FirstOrDefault()?.Price?.Id;
+        return ResolvePlanFromPriceId(priceId, fallback);
+    }
+
+    private SubscriptionPlan ResolvePlanFromPriceId(string? priceId, SubscriptionPlan fallback)
+    {
+        if (string.IsNullOrWhiteSpace(priceId))
+        {
+            return fallback;
+        }
+
+        if (!string.IsNullOrWhiteSpace(_stripeOptions.Prices.Starter) &&
+            string.Equals(priceId, _stripeOptions.Prices.Starter, StringComparison.OrdinalIgnoreCase))
+        {
+            return SubscriptionPlan.Starter;
+        }
+
+        if (!string.IsNullOrWhiteSpace(_stripeOptions.Prices.Pro) &&
+            string.Equals(priceId, _stripeOptions.Prices.Pro, StringComparison.OrdinalIgnoreCase))
+        {
+            return SubscriptionPlan.Pro;
+        }
+
+        if (!string.IsNullOrWhiteSpace(_stripeOptions.Prices.Enterprise) &&
+            string.Equals(priceId, _stripeOptions.Prices.Enterprise, StringComparison.OrdinalIgnoreCase))
+        {
+            return SubscriptionPlan.Enterprise;
+        }
+
+        return fallback;
+    }
+
+    private int GetOrgId()
+    {
+        var claim = User.FindFirstValue("OrgId");
+        if (int.TryParse(claim, NumberStyles.Integer, CultureInfo.InvariantCulture, out var orgId))
+        {
+            return orgId;
+        }
+
+        return 0;
+    }
+
+    private static DateTime? NormalizeToUtc(DateTime? value)
+    {
+        if (!value.HasValue)
+        {
+            return null;
+        }
+
+        var dt = value.Value;
+        if (dt.Kind == DateTimeKind.Unspecified)
+        {
+            dt = DateTime.SpecifyKind(dt, DateTimeKind.Utc);
+        }
+
+        return dt.Kind == DateTimeKind.Utc ? dt : dt.ToUniversalTime();
+    }
+}

--- a/Models/20251215093000_BillingSubscriptions.Designer.cs
+++ b/Models/20251215093000_BillingSubscriptions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TrackHive.Models;
 
@@ -11,9 +12,10 @@ using TrackHive.Models;
 namespace TrackHive.Models
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251215093000_BillingSubscriptions")]
+    partial class BillingSubscriptions : Migration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Models/20251215093000_BillingSubscriptions.cs
+++ b/Models/20251215093000_BillingSubscriptions.cs
@@ -1,0 +1,83 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TrackHive.Models
+{
+    /// <inheritdoc />
+    public partial class BillingSubscriptions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "SubscriptionPlan",
+                table: "Organizations",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "StripeCustomerId",
+                table: "Organizations",
+                type: "nvarchar(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "StripeSubscriptionId",
+                table: "Organizations",
+                type: "nvarchar(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "SubscriptionRenewsAt",
+                table: "Organizations",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "SubscriptionUpdatedAt",
+                table: "Organizations",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Organizations_StripeSubscriptionId",
+                table: "Organizations",
+                column: "StripeSubscriptionId",
+                unique: true,
+                filter: "[StripeSubscriptionId] IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Organizations_StripeSubscriptionId",
+                table: "Organizations");
+
+            migrationBuilder.DropColumn(
+                name: "SubscriptionPlan",
+                table: "Organizations");
+
+            migrationBuilder.DropColumn(
+                name: "StripeCustomerId",
+                table: "Organizations");
+
+            migrationBuilder.DropColumn(
+                name: "StripeSubscriptionId",
+                table: "Organizations");
+
+            migrationBuilder.DropColumn(
+                name: "SubscriptionRenewsAt",
+                table: "Organizations");
+
+            migrationBuilder.DropColumn(
+                name: "SubscriptionUpdatedAt",
+                table: "Organizations");
+        }
+    }
+}

--- a/Models/AppDbContext.cs
+++ b/Models/AppDbContext.cs
@@ -20,6 +20,11 @@ public sealed class AppDbContext : DbContext
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
 
+        modelBuilder.Entity<Organization>()
+            .HasIndex(o => o.StripeSubscriptionId)
+            .IsUnique()
+            .HasFilter("[StripeSubscriptionId] IS NOT NULL");
+
 
         modelBuilder.Entity<AppUser>()
             .Property(u => u.BirthDate)

--- a/Models/BillingViewModels.cs
+++ b/Models/BillingViewModels.cs
@@ -1,0 +1,29 @@
+// File: Models/BillingViewModels.cs
+using System;
+using System.Collections.Generic;
+
+namespace TrackHive.Models;
+
+public sealed class BillingPlanOption
+{
+    public required SubscriptionPlan Plan { get; init; }
+    public required string Title { get; init; }
+    public required string Price { get; init; }
+    public required string Tagline { get; init; }
+    public IReadOnlyList<string> Highlights { get; init; } = Array.Empty<string>();
+}
+
+public sealed class BillingUpgradeViewModel
+{
+    public required IReadOnlyList<BillingPlanOption> Plans { get; init; }
+    public SubscriptionPlan CurrentPlan { get; init; }
+}
+
+public sealed class BillingStatusViewModel
+{
+    public required SubscriptionPlan Plan { get; init; }
+    public required string Title { get; init; }
+    public required string Message { get; init; }
+    public bool Success { get; init; }
+    public DateTime? RenewsAt { get; init; }
+}

--- a/Models/Organization.cs
+++ b/Models/Organization.cs
@@ -14,4 +14,17 @@ public sealed class Organization
     public string CreatedByEmail { get; set; } = string.Empty;
 
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    [Required]
+    public SubscriptionPlan SubscriptionPlan { get; set; } = SubscriptionPlan.Free;
+
+    [StringLength(200)]
+    public string? StripeCustomerId { get; set; }
+
+    [StringLength(200)]
+    public string? StripeSubscriptionId { get; set; }
+
+    public DateTime? SubscriptionRenewsAt { get; set; }
+
+    public DateTime? SubscriptionUpdatedAt { get; set; }
 }

--- a/Models/StripeOptions.cs
+++ b/Models/StripeOptions.cs
@@ -1,0 +1,26 @@
+// File: Models/StripeOptions.cs
+using System.Collections.Generic;
+
+namespace TrackHive.Models;
+
+public sealed class StripeOptions
+{
+    public string PublishableKey { get; set; } = string.Empty;
+    public string SecretKey { get; set; } = string.Empty;
+    public string WebhookSecret { get; set; } = string.Empty;
+    public StripePriceOptions Prices { get; set; } = new();
+
+    public sealed class StripePriceOptions
+    {
+        public string Starter { get; set; } = string.Empty;
+        public string Pro { get; set; } = string.Empty;
+        public string Enterprise { get; set; } = string.Empty;
+
+        public IReadOnlyDictionary<SubscriptionPlan, string> AsDictionary() => new Dictionary<SubscriptionPlan, string>
+        {
+            [SubscriptionPlan.Starter] = Starter,
+            [SubscriptionPlan.Pro] = Pro,
+            [SubscriptionPlan.Enterprise] = Enterprise
+        };
+    }
+}

--- a/Models/SubscriptionPlan.cs
+++ b/Models/SubscriptionPlan.cs
@@ -1,0 +1,10 @@
+// File: Models/SubscriptionPlan.cs
+namespace TrackHive.Models;
+
+public enum SubscriptionPlan
+{
+    Free = 0,
+    Starter = 1,
+    Pro = 2,
+    Enterprise = 3
+}

--- a/Models/SubscriptionPlanExtensions.cs
+++ b/Models/SubscriptionPlanExtensions.cs
@@ -1,0 +1,67 @@
+// File: Models/SubscriptionPlanExtensions.cs
+using System;
+using System.Collections.Generic;
+
+namespace TrackHive.Models;
+
+public static class SubscriptionPlanExtensions
+{
+    private static readonly IReadOnlyDictionary<SubscriptionPlan, SubscriptionPlanCopy> Copy =
+        new Dictionary<SubscriptionPlan, SubscriptionPlanCopy>
+        {
+            [SubscriptionPlan.Free] = new(
+                "Free",
+                "Launch and explore TrackHive with core features for small teams.",
+                "Free forever",
+                new[]
+                {
+                    "Invite up to 3 team members",
+                    "Track attendance and leave basics",
+                    "Email notifications for key workflows"
+                }),
+            [SubscriptionPlan.Starter] = new(
+                "Starter",
+                "Kickstart HR automation for growing teams.",
+                "$99/mo",
+                new[]
+                {
+                    "Up to 25 active employees",
+                    "Full leave & attendance automation",
+                    "Email invites for HR & employees"
+                }),
+            [SubscriptionPlan.Pro] = new(
+                "Pro",
+                "Scale operations with advanced analytics and payroll tools.",
+                "$199/mo",
+                new[]
+                {
+                    "Unlimited team invites",
+                    "Advanced leave + payroll automations",
+                    "Priority email support"
+                }),
+            [SubscriptionPlan.Enterprise] = new(
+                "Enterprise",
+                "Enterprise-grade compliance and onboarding at scale.",
+                "Custom pricing",
+                new[]
+                {
+                    "Dedicated success manager",
+                    "SSO + advanced permissions",
+                    "Unlimited document storage"
+                })
+        };
+
+    public static string GetDisplayName(this SubscriptionPlan plan) =>
+        Copy.TryGetValue(plan, out var value) ? value.DisplayName : plan.ToString();
+
+    public static string GetTagline(this SubscriptionPlan plan) =>
+        Copy.TryGetValue(plan, out var value) ? value.Tagline : string.Empty;
+
+    public static string GetPriceLabel(this SubscriptionPlan plan) =>
+        Copy.TryGetValue(plan, out var value) ? value.Price : string.Empty;
+
+    public static IReadOnlyList<string> GetHighlights(this SubscriptionPlan plan) =>
+        Copy.TryGetValue(plan, out var value) ? value.Features : Array.Empty<string>();
+
+    private sealed record SubscriptionPlanCopy(string DisplayName, string Tagline, string Price, IReadOnlyList<string> Features);
+}

--- a/Program.cs
+++ b/Program.cs
@@ -37,6 +37,8 @@ builder.Services.Configure<SmtpOptions>(builder.Configuration.GetSection("Smtp")
 builder.Services.AddTransient<EmailService>();
 builder.Services.AddScoped<MustChangePasswordFilter>();
 builder.Services.AddSingleton<PayrollPdfGenerator>();
+builder.Services.Configure<StripeOptions>(builder.Configuration.GetSection("Stripe"));
+builder.Services.AddSingleton<BillingService>();
 
 var app = builder.Build();
 

--- a/Services/BillingService.cs
+++ b/Services/BillingService.cs
@@ -1,0 +1,119 @@
+// File: Services/BillingService.cs
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Stripe;
+using Stripe.Checkout;
+using TrackHive.Models;
+
+namespace TrackHive.Services;
+
+public sealed class BillingService
+{
+    private readonly StripeOptions _options;
+    private readonly SessionService _sessionService;
+    private readonly SubscriptionService _subscriptionService;
+    private readonly IReadOnlyDictionary<SubscriptionPlan, string> _priceLookup;
+
+    public BillingService(IOptions<StripeOptions> optionsAccessor)
+    {
+        _options = optionsAccessor?.Value ?? throw new ArgumentNullException(nameof(optionsAccessor));
+
+        if (string.IsNullOrWhiteSpace(_options.SecretKey))
+        {
+            throw new InvalidOperationException("Stripe secret key is not configured.");
+        }
+
+        StripeConfiguration.ApiKey = _options.SecretKey;
+        _priceLookup = _options.Prices.AsDictionary();
+        _sessionService = new SessionService();
+        _subscriptionService = new SubscriptionService();
+    }
+
+    public async Task<Session> CreateCheckoutSessionAsync(
+        int organizationId,
+        SubscriptionPlan plan,
+        string? email,
+        string successUrl,
+        string cancelUrl)
+    {
+        if (!_priceLookup.TryGetValue(plan, out var priceId) || string.IsNullOrWhiteSpace(priceId))
+        {
+            throw new InvalidOperationException($"Stripe price ID is not configured for plan '{plan}'.");
+        }
+
+        var metadata = new Dictionary<string, string>
+        {
+            ["organizationId"] = organizationId.ToString(CultureInfo.InvariantCulture),
+            ["plan"] = plan.ToString()
+        };
+        var subscriptionMetadata = new Dictionary<string, string>(metadata);
+
+        var options = new SessionCreateOptions
+        {
+            Mode = "subscription",
+            SuccessUrl = successUrl,
+            CancelUrl = cancelUrl,
+            CustomerEmail = string.IsNullOrWhiteSpace(email) ? null : email,
+            ClientReferenceId = organizationId.ToString(CultureInfo.InvariantCulture),
+            Metadata = metadata,
+            SubscriptionData = new SessionSubscriptionDataOptions
+            {
+                Metadata = subscriptionMetadata
+            },
+            LineItems = new List<SessionLineItemOptions>
+            {
+                new()
+                {
+                    Price = priceId,
+                    Quantity = 1
+                }
+            }
+        };
+
+        options.PaymentMethodTypes = new List<string> { "card" };
+
+        return await _sessionService.CreateAsync(options);
+    }
+
+    public async Task<Session?> GetSessionAsync(string sessionId)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId))
+        {
+            return null;
+        }
+
+        var options = new SessionGetOptions();
+        options.AddExpand("subscription");
+
+        try
+        {
+            return await _sessionService.GetAsync(sessionId, options);
+        }
+        catch (StripeException)
+        {
+            return null;
+        }
+    }
+
+    public async Task<Subscription?> GetSubscriptionAsync(string subscriptionId)
+    {
+        if (string.IsNullOrWhiteSpace(subscriptionId))
+        {
+            return null;
+        }
+
+        try
+        {
+            return await _subscriptionService.GetAsync(subscriptionId);
+        }
+        catch (StripeException)
+        {
+            return null;
+        }
+    }
+
+    public string GetPublishableKey() => _options.PublishableKey;
+}

--- a/Services/NavigationMenu.cs
+++ b/Services/NavigationMenu.cs
@@ -15,6 +15,7 @@ public static class NavigationMenu
                 new("it-dashboard", "IT Dashboard", "bi-speedometer2", "Dashboard", "Index", "Main"),
                 new("users", "All users", "bi-diagram-3", "Users", "Index", "Admin"),
                 new("people", "People", "bi-people", "Dashboard", "People", "Admin"),
+                new("billing", "Billing & Plans", "bi-credit-card", "Billing", "Upgrade", "Admin"),
                 new("preferences", "Preferences", "bi-sliders2", "Profile", "Preferences", "Admin"),
                 new("profile", "My profile", "bi-person-circle", "Profile", "Index", "Admin"),
             },

--- a/TrackHive.csproj
+++ b/TrackHive.csproj
@@ -19,6 +19,7 @@
     </PackageReference>
     <PackageReference Include="QuestPDF" Version="2024.8.3" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.2" />
+    <PackageReference Include="Stripe.net" Version="47.13.0" />
   </ItemGroup>
 
 

--- a/Views/Billing/Failed.cshtml
+++ b/Views/Billing/Failed.cshtml
@@ -1,0 +1,25 @@
+@model TrackHive.Models.BillingStatusViewModel
+@{
+    Layout = "~/Views/Shared/_Layout.App.cshtml";
+    var planName = Model.Plan.GetDisplayName();
+    var planTagline = Model.Plan.GetTagline();
+}
+
+<div class="row justify-content-center">
+    <div class="col-12 col-lg-10 col-xl-8">
+        <div class="card shadow-sm border-danger">
+            <div class="card-body p-5 text-center">
+                <i class="bi bi-x-circle-fill text-danger display-4 mb-3" aria-hidden="true"></i>
+                <h1 class="h3 mb-3">@Model.Title</h1>
+                <p class="lead mb-3">@planName was not activated.</p>
+                <p class="text-secondary mb-4">@Model.Message</p>
+                <p class="text-secondary small mb-4">@planTagline</p>
+
+                <div class="d-grid d-sm-flex justify-content-center gap-2 mt-4">
+                    <a class="btn btn-primary" asp-action="Upgrade">Try checkout again</a>
+                    <a class="btn btn-outline-secondary" asp-controller="Dashboard" asp-action="Index">Back to invites</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/Views/Billing/Success.cshtml
+++ b/Views/Billing/Success.cshtml
@@ -1,0 +1,40 @@
+@model TrackHive.Models.BillingStatusViewModel
+@{
+    Layout = "~/Views/Shared/_Layout.App.cshtml";
+    var orgName = ViewData["OrgName"] as string ?? "your organization";
+    var planName = Model.Plan.GetDisplayName();
+    var renewsAt = Model.RenewsAt;
+    var localRenewsAt = renewsAt?.ToLocalTime();
+}
+
+<div class="row justify-content-center">
+    <div class="col-12 col-lg-10 col-xl-8">
+        <div class="card shadow-sm">
+            <div class="card-body p-5 text-center">
+                <i class="bi bi-check-circle-fill text-success display-4 mb-3" aria-hidden="true"></i>
+                <h1 class="h3 mb-3">@Model.Title</h1>
+                <p class="lead mb-4">@Model.Message</p>
+
+                <div class="alert alert-success" role="status">
+                    <strong>@planName</strong> features are now unlocked for <strong>@orgName</strong>.
+                </div>
+
+                @if (localRenewsAt.HasValue)
+                {
+                    <p class="text-secondary small mb-4">
+                        Renews on <strong>@localRenewsAt.Value:MMMM d, yyyy</strong> at <strong>@localRenewsAt.Value:HH:mm tt</strong> (local time).
+                    </p>
+                }
+
+                <div class="d-grid d-sm-flex justify-content-center gap-2 mt-4">
+                    <a class="btn btn-primary" asp-controller="Dashboard" asp-action="Index">
+                        Continue inviting HR admins
+                    </a>
+                    <a class="btn btn-outline-secondary" asp-controller="Dashboard" asp-action="People">
+                        Manage people directory
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/Views/Billing/Upgrade.cshtml
+++ b/Views/Billing/Upgrade.cshtml
@@ -1,0 +1,64 @@
+@model TrackHive.Models.BillingUpgradeViewModel
+@{
+    Layout = "~/Views/Shared/_Layout.App.cshtml";
+    var orgName = ViewData["OrgName"] as string ?? "your organization";
+    var currentPlan = Model.CurrentPlan;
+}
+
+<div class="row g-4">
+    <div class="col-12">
+        <div class="d-flex flex-column flex-lg-row align-items-lg-end justify-content-between gap-3">
+            <div>
+                <h1 class="h3 mb-2">Upgrade TrackHive</h1>
+                <p class="text-secondary mb-0">
+                    Choose the plan that fits <strong>@orgName</strong>. You're currently on the
+                    <strong>@currentPlan.GetDisplayName()</strong> plan.
+                </p>
+            </div>
+            @if (TempData["Error"] is string error && !string.IsNullOrWhiteSpace(error))
+            {
+                <div class="alert alert-danger mb-0" role="alert">@error</div>
+            }
+        </div>
+    </div>
+
+    @foreach (var plan in Model.Plans)
+    {
+        var isCurrent = plan.Plan == currentPlan;
+        <div class="col-12 col-md-6 col-xl-4">
+            <div class="card h-100 shadow-sm@(isCurrent ? " border-primary border-2" : string.Empty)">
+                <div class="card-body d-flex flex-column">
+                    <div class="text-uppercase small text-secondary mb-2">@plan.Price</div>
+                    <h2 class="h5 mb-1">@plan.Title</h2>
+                    <p class="text-secondary mb-3">@plan.Tagline</p>
+                    <ul class="list-unstyled small flex-grow-1">
+                        @foreach (var highlight in plan.Highlights)
+                        {
+                            <li class="d-flex align-items-start gap-2 mb-2">
+                                <i class="bi bi-check-circle-fill text-success" aria-hidden="true"></i>
+                                <span>@highlight</span>
+                            </li>
+                        }
+                    </ul>
+
+                    @if (isCurrent)
+                    {
+                        <div class="alert alert-info small mb-0" role="status">
+                            <i class="bi bi-star-fill me-2" aria-hidden="true"></i> Current plan
+                        </div>
+                    }
+                    else
+                    {
+                        <form asp-action="StartCheckout" method="post" class="mt-3">
+                            @Html.AntiForgeryToken()
+                            <input type="hidden" name="plan" value="@plan.Plan" />
+                            <button type="submit" class="btn btn-primary w-100">
+                                Upgrade to @plan.Title
+                            </button>
+                        </form>
+                    }
+                </div>
+            </div>
+        </div>
+    }
+</div>

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -4,5 +4,15 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Stripe": {
+    "PublishableKey": "pk_test_example",
+    "SecretKey": "sk_test_example",
+    "WebhookSecret": "whsec_example",
+    "Prices": {
+      "Starter": "price_starter",
+      "Pro": "price_pro",
+      "Enterprise": "price_enterprise"
+    }
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -16,5 +16,15 @@
     "Host": "mail.ga2wellness.com",
     "Port": 587,
     "EnableSsl": true
+  },
+  "Stripe": {
+    "PublishableKey": "pk_test_example",
+    "SecretKey": "sk_test_example",
+    "WebhookSecret": "whsec_example",
+    "Prices": {
+      "Starter": "price_starter",
+      "Pro": "price_pro",
+      "Enterprise": "price_enterprise"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add Stripe configuration and a billing service to generate Stripe Checkout sessions for Starter, Pro, and Enterprise plans
- build a Billing controller with upgrade, success, cancel, and webhook endpoints plus dedicated status views tied to the product copy
- extend the organization model with subscription metadata, add the supporting migration, and surface billing in the IT navigation

## Testing
- dotnet build *(fails: `command not found: dotnet` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d39f2e9cd0832891515131704fbf40