### PR TITLE
Enforce subscription seat limits on invites

### DIFF
--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -250,7 +250,8 @@ public sealed class AuthController : Controller
         {
             Name = orgName,
             CreatedByEmail = model.Email.Trim(),
-            CreatedAt = DateTime.UtcNow
+            CreatedAt = DateTime.UtcNow,
+            SubscriptionPlan = SubscriptionPlan.Free
         };
         _db.Organizations.Add(org);
         await _db.SaveChangesAsync(); // org.Id available

--- a/Controllers/DashboardController.cs
+++ b/Controllers/DashboardController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.Security.Claims;
 using TrackHive.Models;
+using TrackHive.Services;
 
 namespace TrackHive.Controllers;
 
@@ -21,11 +22,13 @@ public sealed class DashboardController : Controller
 
     private readonly AppDbContext _db;
     private readonly EmailService _email;
+    private readonly SubscriptionUsageService _subscriptionUsage;
 
-    public DashboardController(AppDbContext db, EmailService email)
+    public DashboardController(AppDbContext db, EmailService email, SubscriptionUsageService subscriptionUsage)
     {
         _db = db;
         _email = email;
+        _subscriptionUsage = subscriptionUsage;
     }
 
     [Authorize(Roles = "IT")]
@@ -58,6 +61,17 @@ public sealed class DashboardController : Controller
         if (exists)
         {
             ModelState.AddModelError(nameof(InviteHRViewModel.Email), "This email is already registered.");
+            ViewData["OrgName"] = org.Name;
+            return View("Index", model);
+        }
+
+        var limitCheck = await _subscriptionUsage.CheckCanAddUserAsync(org.Id, RoleType.HR, HttpContext.RequestAborted);
+        if (!limitCheck.CanAdd)
+        {
+            var message = limitCheck.BlockReason
+                ?? "Invite blocked: your organization has reached the HR seat limit. Visit Billing to upgrade.";
+            model.ErrorMessage = message;
+            TempData["UpgradePrompt"] = message;
             ViewData["OrgName"] = org.Name;
             return View("Index", model);
         }
@@ -132,6 +146,15 @@ public sealed class DashboardController : Controller
         if (exists)
         {
             TempData["Error"] = "Email is already registered.";
+            return RedirectToAction(nameof(People), new { tab = returnTab });
+        }
+
+        var limitCheck = await _subscriptionUsage.CheckCanAddUserAsync(orgId, model.Role, HttpContext.RequestAborted);
+        if (!limitCheck.CanAdd)
+        {
+            var message = limitCheck.BlockReason
+                ?? "Invite blocked: you've reached the seat limit for your subscription. Visit Billing to upgrade.";
+            TempData["UpgradePrompt"] = message;
             return RedirectToAction(nameof(People), new { tab = returnTab });
         }
 

--- a/Controllers/HrDashboardController.cs
+++ b/Controllers/HrDashboardController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using TrackHive.Models;
+using TrackHive.Services;
 
 namespace TrackHive.Controllers;
 
@@ -15,6 +16,7 @@ public sealed class HrDashboardController : Controller
 {
     private readonly AppDbContext _db;
     private readonly EmailService _email;
+    private readonly SubscriptionUsageService _subscriptionUsage;
     private const string LeaveActionMessageKey = "LeaveActionMessage";
     private const string LeaveActionErrorKey   = "LeaveActionError";
     private const string CertificateActionMessageKey = "CertificateActionMessage";
@@ -27,10 +29,11 @@ public sealed class HrDashboardController : Controller
         LeaveType.Unpaid    => "Unpaid leave",
         _                   => "Other leave"
     };
-    public HrDashboardController(AppDbContext db, EmailService email)
+    public HrDashboardController(AppDbContext db, EmailService email, SubscriptionUsageService subscriptionUsage)
     {
         _db = db;
         _email = email;
+        _subscriptionUsage = subscriptionUsage;
     }
 
     [HttpGet]
@@ -69,6 +72,16 @@ public sealed class HrDashboardController : Controller
         if (exists)
         {
             ModelState.AddModelError("Invite." + nameof(InviteEmployeeViewModel.Email), "This email is already registered.");
+            return View("Index", await BuildDashboardViewModelAsync(user, model));
+        }
+
+        var limitCheck = await _subscriptionUsage.CheckCanAddUserAsync(org.Id, RoleType.Employee, HttpContext.RequestAborted);
+        if (!limitCheck.CanAdd)
+        {
+            var message = limitCheck.BlockReason
+                ?? "Invite blocked: your plan has reached the employee seat limit. Visit Billing to upgrade.";
+            model.ErrorMessage = message;
+            TempData["UpgradePrompt"] = message;
             return View("Index", await BuildDashboardViewModelAsync(user, model));
         }
 

--- a/Controllers/UsersController.cs
+++ b/Controllers/UsersController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using TrackHive.Models;
+using TrackHive.Services;
 
 namespace TrackHive.Controllers;
 
@@ -13,10 +14,12 @@ namespace TrackHive.Controllers;
 public sealed class UsersController : Controller
 {
     private readonly AppDbContext _db;
+    private readonly SubscriptionUsageService _subscriptionUsage;
 
-    public UsersController(AppDbContext db)
+    public UsersController(AppDbContext db, SubscriptionUsageService subscriptionUsage)
     {
         _db = db;
+        _subscriptionUsage = subscriptionUsage;
     }
 
     [HttpGet]
@@ -176,6 +179,17 @@ public sealed class UsersController : Controller
         if (org is null)
         {
             ModelState.AddModelError(nameof(AdminUserFormViewModel.OrganizationId), "Organization not found.");
+            await PopulateOrganizationsAsync(model);
+            return View(model);
+        }
+
+        var limitCheck = await _subscriptionUsage.CheckCanAddUserAsync(org.Id, model.Role, HttpContext.RequestAborted);
+        if (!limitCheck.CanAdd)
+        {
+            var message = limitCheck.BlockReason
+                ?? "Invite blocked: your subscription plan has reached its seat limit. Visit Billing to upgrade.";
+            ViewData["UpgradePrompt"] = message;
+            ModelState.AddModelError(nameof(AdminUserFormViewModel.Role), message);
             await PopulateOrganizationsAsync(model);
             return View(model);
         }

--- a/Models/20251215094500_AddSubscriptionPlanToOrganizations.cs
+++ b/Models/20251215094500_AddSubscriptionPlanToOrganizations.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TrackHive.Models
+{
+    /// <inheritdoc />
+    public partial class AddSubscriptionPlanToOrganizations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "SubscriptionPlan",
+                table: "Organizations",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SubscriptionPlan",
+                table: "Organizations");
+        }
+    }
+}

--- a/Models/AppDbContextModelSnapshot.cs
+++ b/Models/AppDbContextModelSnapshot.cs
@@ -277,6 +277,9 @@ namespace TrackHive.Models
                         .HasMaxLength(200)
                         .HasColumnType("nvarchar(200)");
 
+                    b.Property<int>("SubscriptionPlan")
+                        .HasColumnType("int");
+
                     b.HasKey("Id");
 
                     b.ToTable("Organizations");

--- a/Models/Organization.cs
+++ b/Models/Organization.cs
@@ -14,4 +14,7 @@ public sealed class Organization
     public string CreatedByEmail { get; set; } = string.Empty;
 
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    [Required]
+    public SubscriptionPlan SubscriptionPlan { get; set; } = SubscriptionPlan.Free;
 }

--- a/Models/SubscriptionPlan.cs
+++ b/Models/SubscriptionPlan.cs
@@ -1,0 +1,8 @@
+namespace TrackHive.Models;
+
+public enum SubscriptionPlan
+{
+    Free = 0,
+    Growth = 1,
+    Enterprise = 2
+}

--- a/Program.cs
+++ b/Program.cs
@@ -37,6 +37,7 @@ builder.Services.Configure<SmtpOptions>(builder.Configuration.GetSection("Smtp")
 builder.Services.AddTransient<EmailService>();
 builder.Services.AddScoped<MustChangePasswordFilter>();
 builder.Services.AddSingleton<PayrollPdfGenerator>();
+builder.Services.AddScoped<SubscriptionUsageService>();
 
 var app = builder.Build();
 

--- a/Services/SubscriptionUsageService.cs
+++ b/Services/SubscriptionUsageService.cs
@@ -1,0 +1,139 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using TrackHive.Models;
+
+namespace TrackHive.Services;
+
+public sealed class SubscriptionUsageService
+{
+    private static readonly SubscriptionPlanLimits DefaultLimits = new(null, null, "Contact support to adjust your subscription plan.");
+
+    private static readonly IReadOnlyDictionary<SubscriptionPlan, SubscriptionPlanLimits> PlanLimits =
+        new Dictionary<SubscriptionPlan, SubscriptionPlanLimits>
+        {
+            [SubscriptionPlan.Free] = new SubscriptionPlanLimits(
+                HrLimit: 1,
+                EmployeeLimit: 10,
+                UpgradeMessage: "Upgrade from Settings → Billing to unlock more seats."),
+            [SubscriptionPlan.Growth] = new SubscriptionPlanLimits(
+                HrLimit: 5,
+                EmployeeLimit: 100,
+                UpgradeMessage: "Upgrade to the Enterprise plan for unlimited seats."),
+            [SubscriptionPlan.Enterprise] = new SubscriptionPlanLimits(
+                HrLimit: null,
+                EmployeeLimit: null,
+                UpgradeMessage: "You're already on the Enterprise plan.")
+        };
+
+    private readonly AppDbContext _db;
+
+    public SubscriptionUsageService(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public SubscriptionPlanLimits GetLimits(SubscriptionPlan plan) =>
+        PlanLimits.TryGetValue(plan, out var limits) ? limits : DefaultLimits;
+
+    public async Task<SubscriptionUsage> GetUsageAsync(int organizationId, CancellationToken cancellationToken = default)
+    {
+        var plan = await _db.Organizations.AsNoTracking()
+            .Where(o => o.Id == organizationId)
+            .Select(o => o.SubscriptionPlan)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        var counts = await _db.Users.AsNoTracking()
+            .Where(u => u.OrganizationId == organizationId && (u.Role == RoleType.HR || u.Role == RoleType.Employee))
+            .GroupBy(u => u.Role)
+            .Select(g => new RoleCount(g.Key, g.Count()))
+            .ToListAsync(cancellationToken);
+
+        var hrCount = counts.FirstOrDefault(c => c.Role == RoleType.HR)?.Count ?? 0;
+        var employeeCount = counts.FirstOrDefault(c => c.Role == RoleType.Employee)?.Count ?? 0;
+
+        var limits = GetLimits(plan);
+        return new SubscriptionUsage(plan, hrCount, employeeCount, limits);
+    }
+
+    public Task<SubscriptionLimitCheckResult> CheckCanAddUserAsync(
+        int organizationId,
+        RoleType role,
+        CancellationToken cancellationToken = default)
+    {
+        if (role is not (RoleType.HR or RoleType.Employee))
+        {
+            return Task.FromResult(SubscriptionLimitCheckResult.Allowed(role));
+        }
+
+        return CheckInternalAsync(organizationId, role, cancellationToken);
+    }
+
+    private async Task<SubscriptionLimitCheckResult> CheckInternalAsync(
+        int organizationId,
+        RoleType role,
+        CancellationToken cancellationToken)
+    {
+        var usage = await GetUsageAsync(organizationId, cancellationToken);
+        var (limit, count, seatLabel) = role == RoleType.HR
+            ? (usage.Limits.HrLimit, usage.HrCount, "HR admins")
+            : (usage.Limits.EmployeeLimit, usage.EmployeeCount, "employees");
+
+        if (limit is null || count < limit.Value)
+        {
+            return SubscriptionLimitCheckResult.Allowed(role, usage, limit);
+        }
+
+        var message = BuildBlockMessage(usage.Plan, seatLabel, limit.Value, count, usage.Limits.UpgradeMessage);
+        return SubscriptionLimitCheckResult.Blocked(role, usage, limit, message);
+    }
+
+    private static string BuildBlockMessage(
+        SubscriptionPlan plan,
+        string seatLabel,
+        int limit,
+        int current,
+        string upgradeMessage)
+    {
+        var planName = plan switch
+        {
+            SubscriptionPlan.Free => "Free",
+            SubscriptionPlan.Growth => "Growth",
+            SubscriptionPlan.Enterprise => "Enterprise",
+            _ => plan.ToString()
+        };
+
+        return $"Invite blocked: the {planName} plan allows up to {limit} {seatLabel} (currently {current}/{limit}). {upgradeMessage}";
+    }
+
+    private sealed record RoleCount(RoleType Role, int Count);
+}
+
+public sealed record SubscriptionPlanLimits(int? HrLimit, int? EmployeeLimit, string UpgradeMessage)
+{
+    public bool HasUnlimitedHr => HrLimit is null;
+    public bool HasUnlimitedEmployees => EmployeeLimit is null;
+}
+
+public sealed record SubscriptionUsage(SubscriptionPlan Plan, int HrCount, int EmployeeCount, SubscriptionPlanLimits Limits);
+
+public sealed record SubscriptionLimitCheckResult(
+    bool CanAdd,
+    RoleType Role,
+    SubscriptionUsage? Usage,
+    int? Limit,
+    string? BlockReason)
+{
+    public static SubscriptionLimitCheckResult Allowed(
+        RoleType role,
+        SubscriptionUsage? usage = null,
+        int? limit = null) => new(true, role, usage, limit, null);
+
+    public static SubscriptionLimitCheckResult Blocked(
+        RoleType role,
+        SubscriptionUsage usage,
+        int? limit,
+        string blockReason) => new(false, role, usage, limit, blockReason);
+}

--- a/Views/Dashboard/People.cshtml
+++ b/Views/Dashboard/People.cshtml
@@ -80,6 +80,13 @@
         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     </div>
 }
+@if (TempData["UpgradePrompt"] is string upgrade)
+{
+    <div class="alert alert-warning alert-dismissible fade show" role="alert">
+        @upgrade
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+}
 
 <div class="card mb-4">
     <div class="card-body">

--- a/Views/Users/Create.cshtml
+++ b/Views/Users/Create.cshtml
@@ -9,6 +9,16 @@
     <a class="btn btn-outline-secondary" asp-action="Index">Back to list</a>
 </div>
 
+@{
+    var upgradePrompt = ViewData["UpgradePrompt"] as string ?? TempData["UpgradePrompt"] as string;
+}
+@if (!string.IsNullOrWhiteSpace(upgradePrompt))
+{
+    <div class="alert alert-warning" role="alert">
+        @upgradePrompt
+    </div>
+}
+
 <div class="card shadow-sm">
     <div class="card-body">
         <form asp-action="Create" method="post" class="row g-3">


### PR DESCRIPTION
## Summary
- add a subscription plan enum and persist each organization’s plan with a migration
- introduce a SubscriptionUsageService that counts HR/employee seats and blocks invites or user creation when limits are exceeded
- surface upgrade CTAs in invite flows and register the new service for dependency injection

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d39f2dfe28832882936a94a8433164