### PR TITLE
Fix merge artifacts and align subscription plans

### DIFF
--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -251,21 +251,13 @@ public sealed class AuthController : Controller
         {
             Name = orgName,
             CreatedByEmail = model.Email.Trim(),
-
             CreatedAt = now,
+            Plan = OrganizationPlan.Free,
             CurrentPlan = SubscriptionPlan.Free,
+            SubscriptionPlan = SubscriptionPlan.Free,
             BillingPeriodStartUtc = now,
             CurrentPeriodEndsUtc = null,
             TrialEndsUtc = now.AddDays(14)
-
-
-            CreatedAt = DateTime.UtcNow,
-            SubscriptionPlan = SubscriptionPlan.Free
-
-            Plan = OrganizationPlan.Free,
-            CreatedAt = DateTime.UtcNow
-
-
         };
         _db.Organizations.Add(org);
         await _db.SaveChangesAsync(); // org.Id available

--- a/Controllers/BillingController.cs
+++ b/Controllers/BillingController.cs
@@ -330,6 +330,7 @@ public sealed class BillingController : Controller
         }
 
         org.SubscriptionPlan = plan;
+        org.CurrentPlan = plan;
         if (!string.IsNullOrWhiteSpace(customerId))
         {
             org.StripeCustomerId = customerId;

--- a/Controllers/HrDashboardController.cs
+++ b/Controllers/HrDashboardController.cs
@@ -447,20 +447,17 @@ public sealed class HrDashboardController : Controller
     private async Task<HrDashboardViewModel> BuildDashboardViewModelAsync(AppUser hr, InviteEmployeeViewModel? inviteOverride)
     {
         var org = await _db.Organizations.AsNoTracking().FirstOrDefaultAsync(o => o.Id == hr.OrganizationId);
-        var plan = org?.Plan ?? OrganizationPlan.Free;
-        var now = DateTimeOffset.UtcNow;
-        var retentionCutoff = RetentionPolicy.GetCutoff(plan, now);
-        var retentionDateCutoff = RetentionPolicy.GetDateCutoff(plan, now);
-        var invite = inviteOverride ?? new InviteEmployeeViewModel();
-
-        var plan = org?.CurrentPlan ?? SubscriptionPlan.Free;
+        var organizationPlan = org?.Plan ?? OrganizationPlan.Free;
+        var subscriptionPlan = org?.SubscriptionPlan ?? SubscriptionPlan.Free;
         var billingStart = org?.BillingPeriodStartUtc ?? hr.CreatedAt;
         var currentPeriodEnds = org?.CurrentPeriodEndsUtc;
         var trialEnds = org?.TrialEndsUtc;
 
-        var plan = org?.Plan ?? OrganizationPlan.Free;
-        var canViewAnalytics = PlanHelper.CanViewAnalytics(plan);
-
+        var now = DateTimeOffset.UtcNow;
+        var retentionCutoff = RetentionPolicy.GetCutoff(organizationPlan, now);
+        var retentionDateCutoff = RetentionPolicy.GetDateCutoff(organizationPlan, now);
+        var invite = inviteOverride ?? new InviteEmployeeViewModel();
+        var canViewAnalytics = PlanHelper.CanViewAnalytics(organizationPlan);
 
         var employees = await _db.Users
             .AsNoTracking()
@@ -481,9 +478,9 @@ public sealed class HrDashboardController : Controller
             .Include(r => r.User)
             .Where(r => employeeIds.Contains(r.UserId) && r.Status == LeaveRequestStatus.Pending);
 
-        if (retentionCutoff is DateTimeOffset retention)
+        if (retentionCutoff is DateTimeOffset pendingCutoff)
         {
-            pendingRequestQuery = pendingRequestQuery.Where(r => r.CreatedAt >= retention);
+            pendingRequestQuery = pendingRequestQuery.Where(r => r.CreatedAt >= pendingCutoff);
         }
 
         var pendingRequests = await pendingRequestQuery
@@ -695,6 +692,9 @@ public sealed class HrDashboardController : Controller
             {
                 attendanceWindowStart = retentionAttendance;
             }
+
+            static bool IsLate(DateTimeOffset checkInLocal, TimeSpan threshold) => checkInLocal.TimeOfDay > threshold;
+
             var recentAttendance = await _db.AttendanceRecords
                 .AsNoTracking()
                 .Where(a => employeeIds.Contains(a.UserId)
@@ -702,8 +702,6 @@ public sealed class HrDashboardController : Controller
                     && a.CheckInTime != null)
                 .Select(a => new { a.UserId, a.Date, a.CheckInTime })
                 .ToListAsync();
-
-            static bool IsLate(DateTimeOffset checkInLocal, TimeSpan threshold) => checkInLocal.TimeOfDay > threshold;
 
             var lateArrivals = recentAttendance
                 .Select(a => new
@@ -736,16 +734,17 @@ public sealed class HrDashboardController : Controller
             }
 
             var today = DateOnly.FromDateTime(now.UtcDateTime);
-            var monthStart = new DateOnly(today.Year, today.Month, 1);
-            if (retentionDateCutoff is DateOnly retentionMonthStart && retentionMonthStart > monthStart)
+            var monthStartDate = new DateOnly(today.Year, today.Month, 1);
+            if (retentionDateCutoff is DateOnly retentionMonthStart && retentionMonthStart > monthStartDate)
             {
-                monthStart = retentionMonthStart;
+                monthStartDate = retentionMonthStart;
             }
-            var nextMonth = monthStart.AddMonths(1);
+
+            var nextMonth = monthStartDate.AddMonths(1);
             var monthAttendance = await _db.AttendanceRecords
                 .AsNoTracking()
                 .Where(a => employeeIds.Contains(a.UserId)
-                    && a.Date >= monthStart
+                    && a.Date >= monthStartDate
                     && a.Date < nextMonth)
                 .Select(a => new { a.UserId, a.Date, a.CheckInTime })
                 .ToListAsync();
@@ -762,7 +761,7 @@ public sealed class HrDashboardController : Controller
                 notifications.Add(new DashboardNotificationViewModel
                 {
                     Category = "Reports",
-                    Title = $"{monthStart:MMMM yyyy} attendance summary",
+                    Title = $"{monthStartDate:MMMM yyyy} attendance summary",
                     Message = $"{totalCheckIns} check-in(s) recorded across {employeesActive} employee(s) with {lateCount} late arrival(s).",
                     CreatedAt = now
                 });
@@ -773,7 +772,6 @@ public sealed class HrDashboardController : Controller
             .OrderByDescending(n => n.CreatedAt ?? DateTimeOffset.MinValue)
             .Take(10)
             .ToList();
-
 
         var currentMonthUtc = new DateTime(now.UtcDateTime.Year, now.UtcDateTime.Month, 1, 0, 0, 0, DateTimeKind.Utc);
         var monthCandidates = Enumerable.Range(0, 6)
@@ -808,20 +806,25 @@ public sealed class HrDashboardController : Controller
             })
             .ToList();
 
-        var monthlyTrends = new List<MonthlyLeaveTrendViewModel>();
+        var monthlyTrends = monthRange
+            .Select(info => new MonthlyLeaveTrendViewModel
+            {
+                MonthLabel = info.Label,
+                Pending = 0,
+                Approved = 0,
+                Rejected = 0
+            })
+            .ToList();
+
         var leaveTypeBreakdown = new List<LeaveTypeBreakdownViewModel>();
-
         var leavesReviewedThisMonth = 0;
-        IReadOnlyList<MonthlyLeaveTrendViewModel> monthlyTrends = Array.Empty<MonthlyLeaveTrendViewModel>();
-        IReadOnlyList<LeaveTypeBreakdownViewModel> leaveTypeBreakdown = Array.Empty<LeaveTypeBreakdownViewModel>();
 
-        if (canViewAnalytics)
+        if (canViewAnalytics && employeeIds.Count > 0)
         {
-
             var earliestMonth = monthRange.First().Date;
             var leaveHistoryQuery = _db.LeaveRequests
                 .AsNoTracking()
-                .Where(r => employeeIds.Contains(r.UserId));
+                .Where(r => employeeIds.Contains(r.UserId) && r.CreatedAt >= earliestMonth);
 
             if (retentionCutoff is DateTimeOffset historyCutoff)
             {
@@ -829,104 +832,40 @@ public sealed class HrDashboardController : Controller
             }
 
             var leaveHistory = await leaveHistoryQuery
-                .Where(r => r.CreatedAt >= earliestMonth)
                 .Select(r => new { r.CreatedAt, r.Status })
                 .ToListAsync();
 
-            var currentMonthUtc = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1, 0, 0, 0, DateTimeKind.Utc);
-            var monthRange = Enumerable.Range(0, 6)
-                .Select(offset => currentMonthUtc.AddMonths(offset - 5))
-                .Select(date => new
-                {
-                    Date = date,
-                    Label = date.ToString("MMM yyyy", CultureInfo.InvariantCulture)
-                })
-                .ToList();
+            var monthlyLookup = leaveHistory
+                .GroupBy(r => new DateTime(r.CreatedAt.Year, r.CreatedAt.Month, 1, 0, 0, 0, DateTimeKind.Utc))
+                .ToDictionary(
+                    g => g.Key,
+                    g =>
+                    {
+                        var pending = g.Count(x => x.Status == LeaveRequestStatus.Pending || x.Status == LeaveRequestStatus.AwaitingCertificateReview);
+                        var approved = g.Count(x => x.Status == LeaveRequestStatus.Approved || x.Status == LeaveRequestStatus.ApprovedAwaitingCertificate);
+                        var rejected = g.Count(x => x.Status == LeaveRequestStatus.Rejected || x.Status == LeaveRequestStatus.CertificateRejected);
+                        return (Pending: pending, Approved: approved, Rejected: rejected);
+                    });
 
-
-            var trendList = new List<MonthlyLeaveTrendViewModel>();
-            var breakdownList = new List<LeaveTypeBreakdownViewModel>();
-
-            if (employeeIds.Count > 0)
+            for (var i = 0; i < monthRange.Count; i++)
             {
-                var earliestMonth = monthRange.First().Date;
-                var leaveHistory = await _db.LeaveRequests
-                    .AsNoTracking()
-                    .Where(r => employeeIds.Contains(r.UserId) && r.CreatedAt >= earliestMonth)
-                    .Select(r => new { r.CreatedAt, r.Status })
-                    .ToListAsync();
-
-                var monthlyLookup = leaveHistory
-                    .GroupBy(r => new DateTime(r.CreatedAt.Year, r.CreatedAt.Month, 1, 0, 0, 0, DateTimeKind.Utc))
-                    .ToDictionary(
-                        g => g.Key,
-                        g =>
-                        {
-                            var pending = g.Count(x => x.Status == LeaveRequestStatus.Pending || x.Status == LeaveRequestStatus.AwaitingCertificateReview);
-                            var approved = g.Count(x => x.Status == LeaveRequestStatus.Approved || x.Status == LeaveRequestStatus.ApprovedAwaitingCertificate);
-                            var rejected = g.Count(x => x.Status == LeaveRequestStatus.Rejected || x.Status == LeaveRequestStatus.CertificateRejected);
-                            return (Pending: pending, Approved: approved, Rejected: rejected);
-                        });
-
-                foreach (var info in monthRange)
+                var info = monthRange[i];
+                if (monthlyLookup.TryGetValue(info.Date, out var counts))
                 {
-                    if (monthlyLookup.TryGetValue(info.Date, out var counts))
-                    {
-                        trendList.Add(new MonthlyLeaveTrendViewModel
-                        {
-                            MonthLabel = info.Label,
-                            Pending = counts.Pending,
-                            Approved = counts.Approved,
-                            Rejected = counts.Rejected
-                        });
-
-                        if (info.Date == currentMonthUtc)
-                        {
-                            leavesReviewedThisMonth = counts.Approved + counts.Rejected;
-                        }
-                    }
-                    else
-                    {
-                        trendList.Add(new MonthlyLeaveTrendViewModel
-                        {
-                            MonthLabel = info.Label,
-                            Pending = 0,
-                            Approved = 0,
-                            Rejected = 0
-                        });
-                    }
-                }
-
-                var typeCounts = await _db.LeaveRequests
-                    .AsNoTracking()
-                    .Where(r => employeeIds.Contains(r.UserId))
-                    .GroupBy(r => r.Type)
-                    .Select(g => new { Type = g.Key, Count = g.Count() })
-                    .ToListAsync();
-
-                breakdownList = typeCounts
-                    .OrderByDescending(t => t.Count)
-                    .Select(t => new LeaveTypeBreakdownViewModel
-                    {
-                        Type = FormatLeaveType(t.Type),
-                        Count = t.Count
-                    })
-                    .ToList();
-            }
-
-            if (trendList.Count == 0)
-            {
-                trendList = monthRange
-                    .Select(info => new MonthlyLeaveTrendViewModel
+                    monthlyTrends[i] = new MonthlyLeaveTrendViewModel
                     {
                         MonthLabel = info.Label,
-                        Pending = 0,
-                        Approved = 0,
-                        Rejected = 0
-                    })
-                    .ToList();
-            }
+                        Pending = counts.Pending,
+                        Approved = counts.Approved,
+                        Rejected = counts.Rejected
+                    };
 
+                    if (info.Date == currentMonthUtc)
+                    {
+                        leavesReviewedThisMonth = counts.Approved + counts.Rejected;
+                    }
+                }
+            }
 
             var leaveTypeQuery = _db.LeaveRequests
                 .AsNoTracking()
@@ -952,23 +891,6 @@ public sealed class HrDashboardController : Controller
                 .ToList();
         }
 
-        if (monthlyTrends.Count == 0)
-        {
-            monthlyTrends = monthRange
-                .Select(info => new MonthlyLeaveTrendViewModel
-                {
-                    MonthLabel = info.Label,
-                    Pending = 0,
-                    Approved = 0,
-                    Rejected = 0
-                })
-                .ToList();
-
-            monthlyTrends = trendList;
-            leaveTypeBreakdown = breakdownList;
-
-        }
-
         var metrics = new DashboardMetricsViewModel
         {
             TotalEmployees = employees.Count,
@@ -983,7 +905,7 @@ public sealed class HrDashboardController : Controller
         return new HrDashboardViewModel
         {
             OrganizationName = org?.Name ?? "Organization",
-            CurrentPlan = plan,
+            CurrentPlan = subscriptionPlan,
             BillingPeriodStartUtc = billingStart,
             CurrentPeriodEndsUtc = currentPeriodEnds,
             TrialEndsUtc = trialEnds,
@@ -993,7 +915,7 @@ public sealed class HrDashboardController : Controller
             LeaveSummaries = leaveSummaries,
             Notifications = orderedNotifications,
             Metrics = metrics,
-            Plan = plan,
+            Plan = organizationPlan,
             CanViewAnalytics = canViewAnalytics
         };
     }

--- a/Controllers/PayrollController.cs
+++ b/Controllers/PayrollController.cs
@@ -31,10 +31,7 @@ public sealed class PayrollController : Controller
         if (hr is null) return RedirectToAction("Login", "Auth");
         if (hr.MustChangePassword) return RedirectToAction("ChangePassword", "Auth");
 
-
         var employees = await LoadEmployeesAsync(hr.OrganizationId);
-        var plan = await GetOrganizationPlanAsync(hr.OrganizationId);
-
         var plan = await GetOrganizationPlanAsync(hr.OrganizationId);
         var canUsePayroll = PlanHelper.CanAccessPayroll(plan);
         var canExportPdf = PlanHelper.CanExportPdf(plan);
@@ -53,6 +50,7 @@ public sealed class PayrollController : Controller
         {
             var restrictedModel = new PayrollIndexViewModel
             {
+                Employees = employees,
                 Plan = plan,
                 CanUsePayroll = false,
                 CanExportPdf = canExportPdf,
@@ -61,8 +59,6 @@ public sealed class PayrollController : Controller
 
             return View(restrictedModel);
         }
-
-        var employees = await LoadEmployeesAsync(hr.OrganizationId);
 
         PayrollCalculationResult? result = null;
         IReadOnlyList<PastPayrollRecordViewModel> history = Array.Empty<PastPayrollRecordViewModel>();
@@ -112,10 +108,13 @@ public sealed class PayrollController : Controller
         var canUsePayroll = PlanHelper.CanAccessPayroll(plan);
         var canExportPdf = PlanHelper.CanExportPdf(plan);
 
+        var employees = await LoadEmployeesAsync(hr.OrganizationId);
+
         if (!canUsePayroll)
         {
             var restrictedModel = new PayrollIndexViewModel
             {
+                Employees = employees,
                 Plan = plan,
                 CanUsePayroll = false,
                 CanExportPdf = canExportPdf,
@@ -124,9 +123,6 @@ public sealed class PayrollController : Controller
 
             return View("Index", restrictedModel);
         }
-
-        var employees = await LoadEmployeesAsync(hr.OrganizationId);
-        var plan = await GetOrganizationPlanAsync(hr.OrganizationId);
         PayrollCalculationResult? result = null;
         IReadOnlyList<PastPayrollRecordViewModel> history = Array.Empty<PastPayrollRecordViewModel>();
         string? alertMessage = null;
@@ -549,15 +545,6 @@ public sealed class PayrollController : Controller
         var idStr = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (!int.TryParse(idStr, out var id)) return null;
         return await _db.Users.FindAsync(id);
-    }
-
-    private async Task<OrganizationPlan> GetOrganizationPlanAsync(int organizationId)
-    {
-        return await _db.Organizations
-            .AsNoTracking()
-            .Where(o => o.Id == organizationId)
-            .Select(o => o.Plan)
-            .FirstOrDefaultAsync();
     }
 
     private async Task<List<PayrollEmployeeOption>> LoadEmployeesAsync(int organizationId)

--- a/Models/Organization.cs
+++ b/Models/Organization.cs
@@ -3,14 +3,6 @@ using System.ComponentModel.DataAnnotations;
 
 namespace TrackHive.Models;
 
-public enum SubscriptionPlan
-{
-    Free,
-    Starter,
-    Pro,
-    Enterprise
-}
-
 public sealed class Organization
 {
     public int Id { get; set; }
@@ -21,15 +13,9 @@ public sealed class Organization
     [Required, EmailAddress]
     public string CreatedByEmail { get; set; } = string.Empty;
 
-    [Required]
-    public OrganizationPlan Plan { get; set; } = OrganizationPlan.Free;
-
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
-
     public OrganizationPlan Plan { get; set; } = OrganizationPlan.Free;
-
-    [Required]
 
     public SubscriptionPlan CurrentPlan { get; set; } = SubscriptionPlan.Free;
 
@@ -40,7 +26,6 @@ public sealed class Organization
     public DateTime? TrialEndsUtc { get; set; }
 
     public SubscriptionPlan SubscriptionPlan { get; set; } = SubscriptionPlan.Free;
-
 
     [StringLength(200)]
     public string? StripeCustomerId { get; set; }

--- a/Models/OrganizationPlan.cs
+++ b/Models/OrganizationPlan.cs
@@ -3,12 +3,7 @@ namespace TrackHive.Models;
 public enum OrganizationPlan
 {
     Free = 0,
-
-    Pro = 1,
-    Enterprise = 2
-
     Starter = 1,
-    Growth = 2,
-    Scale = 3
-
+    Pro = 2,
+    Enterprise = 3
 }

--- a/Models/PlanHelper.cs
+++ b/Models/PlanHelper.cs
@@ -2,8 +2,8 @@ namespace TrackHive.Models;
 
 public static class PlanHelper
 {
-    public const OrganizationPlan PayrollRequiredPlan = OrganizationPlan.Growth;
-    public const OrganizationPlan AnalyticsRequiredPlan = OrganizationPlan.Growth;
+    public const OrganizationPlan PayrollRequiredPlan = OrganizationPlan.Pro;
+    public const OrganizationPlan AnalyticsRequiredPlan = OrganizationPlan.Pro;
     public const OrganizationPlan PdfRequiredPlan = OrganizationPlan.Starter;
 
     public static bool CanAccessPayroll(OrganizationPlan plan) => plan >= PayrollRequiredPlan;
@@ -18,8 +18,8 @@ public static class PlanHelper
     {
         OrganizationPlan.Free => "Free",
         OrganizationPlan.Starter => "Starter",
-        OrganizationPlan.Growth => "Growth",
-        OrganizationPlan.Scale => "Scale",
+        OrganizationPlan.Pro => "Pro",
+        OrganizationPlan.Enterprise => "Enterprise",
         _ => plan.ToString()
     };
 }

--- a/Models/SubscriptionPlan.cs
+++ b/Models/SubscriptionPlan.cs
@@ -6,12 +6,7 @@ namespace TrackHive.Models;
 public enum SubscriptionPlan
 {
     Free = 0,
-
-    Growth = 1,
-    Enterprise = 2
-
     Starter = 1,
     Pro = 2,
     Enterprise = 3
-
 }

--- a/Services/SubscriptionUsageService.cs
+++ b/Services/SubscriptionUsageService.cs
@@ -18,10 +18,14 @@ public sealed class SubscriptionUsageService
                 HrLimit: 1,
                 EmployeeLimit: 10,
                 UpgradeMessage: "Upgrade from Settings → Billing to unlock more seats."),
-            [SubscriptionPlan.Growth] = new SubscriptionPlanLimits(
-                HrLimit: 5,
-                EmployeeLimit: 100,
-                UpgradeMessage: "Upgrade to the Enterprise plan for unlimited seats."),
+            [SubscriptionPlan.Starter] = new SubscriptionPlanLimits(
+                HrLimit: 3,
+                EmployeeLimit: 25,
+                UpgradeMessage: "Upgrade to the Pro plan to invite more teammates."),
+            [SubscriptionPlan.Pro] = new SubscriptionPlanLimits(
+                HrLimit: null,
+                EmployeeLimit: null,
+                UpgradeMessage: "Upgrade to the Enterprise plan for dedicated onboarding."),
             [SubscriptionPlan.Enterprise] = new SubscriptionPlanLimits(
                 HrLimit: null,
                 EmployeeLimit: null,
@@ -97,13 +101,7 @@ public sealed class SubscriptionUsageService
         int current,
         string upgradeMessage)
     {
-        var planName = plan switch
-        {
-            SubscriptionPlan.Free => "Free",
-            SubscriptionPlan.Growth => "Growth",
-            SubscriptionPlan.Enterprise => "Enterprise",
-            _ => plan.ToString()
-        };
+        var planName = plan.GetDisplayName();
 
         return $"Invite blocked: the {planName} plan allows up to {limit} {seatLabel} (currently {current}/{limit}). {upgradeMessage}";
     }


### PR DESCRIPTION
## Summary
- unify `OrganizationPlan` and `SubscriptionPlan` enums and update helpers, models and services to use the same plan names
- clean up merge leftovers in organization/billing/auth flows so plan information stays in sync
- rebuild the HR dashboard model builder and payroll controller helpers to remove duplicated logic and ensure accurate data

## Testing
- `dotnet test` *(fails: `dotnet` is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3ac4a740c8328b1c4a951cc8f0989