### PR TITLE
Fix Stripe API integration for latest SDK

### DIFF
--- a/Controllers/BillingController.cs
+++ b/Controllers/BillingController.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Options;
 using Stripe;
 using Stripe.Checkout;
 using TrackHive.Models;
-using TrackHive.Services;
+using BillingService = TrackHive.Services.BillingService;
 
 namespace TrackHive.Controllers;
 
@@ -171,14 +171,14 @@ public sealed class BillingController : Controller
         {
             switch (stripeEvent.Type)
             {
-                case Events.CheckoutSessionCompleted:
+                case EventTypes.CheckoutSessionCompleted:
                     if (stripeEvent.Data.Object is Session checkoutSession)
                     {
                         await HandleCheckoutSessionAsync(checkoutSession);
                     }
                     break;
-                case Events.CustomerSubscriptionCreated:
-                case Events.CustomerSubscriptionUpdated:
+                case EventTypes.CustomerSubscriptionCreated:
+                case EventTypes.CustomerSubscriptionUpdated:
                     if (stripeEvent.Data.Object is Subscription subscription)
                     {
                         await HandleSubscriptionAsync(subscription);
@@ -225,7 +225,7 @@ public sealed class BillingController : Controller
         DateTime? renewsAt = null;
         if (session.Subscription is Subscription subscription)
         {
-            renewsAt = NormalizeToUtc(subscription.CurrentPeriodEnd);
+            renewsAt = NormalizeToUtc(GetSubscriptionPeriodEnd(subscription));
         }
 
         var vm = new BillingStatusViewModel
@@ -292,7 +292,7 @@ public sealed class BillingController : Controller
             plan,
             session.CustomerId,
             subscription?.Id ?? subscriptionId,
-            subscription?.CurrentPeriodEnd);
+            GetSubscriptionPeriodEnd(subscription));
     }
 
     private async Task HandleSubscriptionAsync(Subscription subscription)
@@ -312,7 +312,7 @@ public sealed class BillingController : Controller
             plan,
             subscription.CustomerId,
             subscription.Id,
-            subscription.CurrentPeriodEnd);
+            GetSubscriptionPeriodEnd(subscription));
     }
 
     private async Task UpdateOrganizationSubscriptionAsync(
@@ -421,6 +421,23 @@ public sealed class BillingController : Controller
         }
 
         return fallback;
+    }
+
+    private static DateTime? GetSubscriptionPeriodEnd(Subscription? subscription)
+    {
+        var item = subscription?.Items?.Data?.FirstOrDefault();
+        if (item is null)
+        {
+            return null;
+        }
+
+        var periodEnd = item.CurrentPeriodEnd;
+        if (periodEnd <= DateTime.UnixEpoch)
+        {
+            return null;
+        }
+
+        return periodEnd;
     }
 
     private int GetOrgId()

--- a/Services/BillingService.cs
+++ b/Services/BillingService.cs
@@ -87,6 +87,7 @@ public sealed class BillingService
 
         var options = new SessionGetOptions();
         options.AddExpand("subscription");
+        options.AddExpand("subscription.items.data.price");
 
         try
         {
@@ -105,9 +106,12 @@ public sealed class BillingService
             return null;
         }
 
+        var options = new SubscriptionGetOptions();
+        options.AddExpand("items.data.price");
+
         try
         {
-            return await _subscriptionService.GetAsync(subscriptionId);
+            return await _subscriptionService.GetAsync(subscriptionId, options);
         }
         catch (StripeException)
         {


### PR DESCRIPTION
## Summary
- update billing webhook handling to use Stripe EventTypes constants and retrieve renewal dates from subscription items
- expand Stripe sessions and subscriptions to include price data and avoid type name clashes with Stripe's BillingService

## Testing
- dotnet test TrackHive.sln *(fails: build error from duplicate OrganizationPlans migration classes present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b82bc8dc83289929cc107ec1127c