### PR TITLE
Fix Stripe checkout success URL placeholder encoding

### DIFF
--- a/Controllers/BillingController.cs
+++ b/Controllers/BillingController.cs
@@ -8,7 +8,6 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -105,7 +104,7 @@ public sealed class BillingController : Controller
             {
                 throw new InvalidOperationException("Unable to resolve the success URL.");
             }
-            successUrl = QueryHelpers.AddQueryString(successUrl, "session_id", "{CHECKOUT_SESSION_ID}");
+            successUrl = AppendCheckoutSessionId(successUrl);
 
             var cancelUrl = Url.Action(nameof(Failed), "Billing", new { plan }, Request.Scheme, Request.Host.ToString());
             if (string.IsNullOrWhiteSpace(cancelUrl))
@@ -267,6 +266,22 @@ public sealed class BillingController : Controller
         Tagline = plan.GetTagline(),
         Highlights = plan.GetHighlights()
     };
+
+    internal static string AppendCheckoutSessionId(string baseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            throw new ArgumentException("Base URL cannot be null or whitespace.", nameof(baseUrl));
+        }
+
+        if (baseUrl.Contains("session_id={CHECKOUT_SESSION_ID}", StringComparison.Ordinal))
+        {
+            return baseUrl;
+        }
+
+        var separator = baseUrl.Contains('?', StringComparison.Ordinal) ? '&' : '?';
+        return $"{baseUrl}{separator}session_id={{CHECKOUT_SESSION_ID}}";
+    }
 
     private async Task HandleCheckoutSessionAsync(Session session)
     {

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("TrackHive.Tests")]

--- a/TrackHive.Tests/BillingControllerTests.cs
+++ b/TrackHive.Tests/BillingControllerTests.cs
@@ -1,0 +1,45 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TrackHive.Controllers;
+
+namespace TrackHive.Tests;
+
+[TestClass]
+public class BillingControllerTests
+{
+    [TestMethod]
+    public void AppendCheckoutSessionId_AppendsPlaceholder_WhenQueryMissing()
+    {
+        var baseUrl = "https://example.com/Billing/Success";
+
+        var result = BillingController.AppendCheckoutSessionId(baseUrl);
+
+        Assert.AreEqual("https://example.com/Billing/Success?session_id={CHECKOUT_SESSION_ID}", result);
+    }
+
+    [TestMethod]
+    public void AppendCheckoutSessionId_AppendsWithAmpersand_WhenQueryExists()
+    {
+        var baseUrl = "https://example.com/Billing/Success?foo=bar";
+
+        var result = BillingController.AppendCheckoutSessionId(baseUrl);
+
+        Assert.AreEqual("https://example.com/Billing/Success?foo=bar&session_id={CHECKOUT_SESSION_ID}", result);
+    }
+
+    [TestMethod]
+    public void AppendCheckoutSessionId_DoesNotDuplicatePlaceholder()
+    {
+        var baseUrl = "https://example.com/Billing/Success?session_id={CHECKOUT_SESSION_ID}";
+
+        var result = BillingController.AppendCheckoutSessionId(baseUrl);
+
+        Assert.AreEqual(baseUrl, result);
+    }
+
+    [TestMethod]
+    public void AppendCheckoutSessionId_ThrowsForEmptyUrl()
+    {
+        Assert.ThrowsException<ArgumentException>(() => BillingController.AppendCheckoutSessionId(" "));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the Stripe checkout success URL preserves the `{CHECKOUT_SESSION_ID}` placeholder instead of URL-encoding it
- expose the helper for testing and cover the success URL builder logic with unit tests

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d3c2543978832886a8dc3de4e15c8a