### PR TITLE
Handle checkout success URLs with fragments

### DIFF
--- a/Controllers/BillingController.cs
+++ b/Controllers/BillingController.cs
@@ -279,8 +279,13 @@ public sealed class BillingController : Controller
             return baseUrl;
         }
 
-        var separator = baseUrl.Contains('?', StringComparison.Ordinal) ? '&' : '?';
-        return $"{baseUrl}{separator}session_id={{CHECKOUT_SESSION_ID}}";
+        var fragmentIndex = baseUrl.IndexOf('#');
+        var hasFragment = fragmentIndex >= 0;
+        var fragment = hasFragment ? baseUrl.Substring(fragmentIndex) : string.Empty;
+        var withoutFragment = hasFragment ? baseUrl[..fragmentIndex] : baseUrl;
+
+        var separator = withoutFragment.Contains('?', StringComparison.Ordinal) ? '&' : '?';
+        return $"{withoutFragment}{separator}session_id={{CHECKOUT_SESSION_ID}}{fragment}";
     }
 
     private async Task HandleCheckoutSessionAsync(Session session)

--- a/TrackHive.Tests/BillingControllerTests.cs
+++ b/TrackHive.Tests/BillingControllerTests.cs
@@ -38,6 +38,16 @@ public class BillingControllerTests
     }
 
     [TestMethod]
+    public void AppendCheckoutSessionId_InsertsBeforeFragment()
+    {
+        var baseUrl = "https://example.com/Billing/Success?foo=bar#section";
+
+        var result = BillingController.AppendCheckoutSessionId(baseUrl);
+
+        Assert.AreEqual("https://example.com/Billing/Success?foo=bar&session_id={CHECKOUT_SESSION_ID}#section", result);
+    }
+
+    [TestMethod]
     public void AppendCheckoutSessionId_ThrowsForEmptyUrl()
     {
         Assert.ThrowsException<ArgumentException>(() => BillingController.AppendCheckoutSessionId(" "));


### PR DESCRIPTION
## Summary
- ensure the checkout success URL adds the session placeholder before any fragment so Stripe can append the session id properly
- extend the AppendCheckoutSessionId unit tests to cover fragment handling

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d3c446880c8328be79522c31d95b8c