### PR TITLE
Support Stripe price lookup keys when starting checkout

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -44,6 +44,7 @@ builder.Services.AddHostedService<DataRetentionService>();
 builder.Services.AddScoped<SubscriptionUsageService>();
 
 builder.Services.Configure<StripeOptions>(builder.Configuration.GetSection("Stripe"));
+builder.Services.AddSingleton<IStripePriceLookupService, StripePriceLookupService>();
 builder.Services.AddSingleton<BillingService>();
 
 

--- a/Services/BillingService.cs
+++ b/Services/BillingService.cs
@@ -1,5 +1,6 @@
 // File: Services/BillingService.cs
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
@@ -15,9 +16,13 @@ public sealed class BillingService
     private readonly StripeOptions _options;
     private readonly SessionService _sessionService;
     private readonly SubscriptionService _subscriptionService;
-    private readonly IReadOnlyDictionary<SubscriptionPlan, string> _priceLookup;
+    private readonly IReadOnlyDictionary<SubscriptionPlan, string> _configuredPrices;
+    private readonly IStripePriceLookupService _priceLookupService;
+    private readonly ConcurrentDictionary<string, string> _priceIdCache = new(StringComparer.OrdinalIgnoreCase);
 
-    public BillingService(IOptions<StripeOptions> optionsAccessor)
+    public BillingService(
+        IOptions<StripeOptions> optionsAccessor,
+        IStripePriceLookupService priceLookupService)
     {
         _options = optionsAccessor?.Value ?? throw new ArgumentNullException(nameof(optionsAccessor));
 
@@ -27,7 +32,8 @@ public sealed class BillingService
         }
 
         StripeConfiguration.ApiKey = _options.SecretKey;
-        _priceLookup = _options.Prices.AsDictionary();
+        _configuredPrices = _options.Prices.AsDictionary();
+        _priceLookupService = priceLookupService ?? throw new ArgumentNullException(nameof(priceLookupService));
         _sessionService = new SessionService();
         _subscriptionService = new SubscriptionService();
     }
@@ -39,10 +45,7 @@ public sealed class BillingService
         string successUrl,
         string cancelUrl)
     {
-        if (!_priceLookup.TryGetValue(plan, out var priceId) || string.IsNullOrWhiteSpace(priceId))
-        {
-            throw new InvalidOperationException($"Stripe price ID is not configured for plan '{plan}'.");
-        }
+        var priceId = await ResolvePriceIdAsync(plan);
 
         var metadata = new Dictionary<string, string>
         {
@@ -120,4 +123,31 @@ public sealed class BillingService
     }
 
     public string GetPublishableKey() => _options.PublishableKey;
+
+    private async Task<string> ResolvePriceIdAsync(SubscriptionPlan plan)
+    {
+        if (!_configuredPrices.TryGetValue(plan, out var configuredValue) || string.IsNullOrWhiteSpace(configuredValue))
+        {
+            throw new InvalidOperationException($"Stripe price ID is not configured for plan '{plan}'.");
+        }
+
+        if (configuredValue.StartsWith("price_", StringComparison.OrdinalIgnoreCase))
+        {
+            return configuredValue;
+        }
+
+        if (_priceIdCache.TryGetValue(configuredValue, out var cached))
+        {
+            return cached;
+        }
+
+        var priceId = await _priceLookupService.GetPriceIdByLookupKeyAsync(configuredValue);
+        if (string.IsNullOrWhiteSpace(priceId))
+        {
+            throw new InvalidOperationException($"Stripe price lookup key '{configuredValue}' is not associated with a price.");
+        }
+
+        _priceIdCache[configuredValue] = priceId;
+        return priceId;
+    }
 }

--- a/Services/StripePriceLookupService.cs
+++ b/Services/StripePriceLookupService.cs
@@ -1,0 +1,39 @@
+// File: Services/StripePriceLookupService.cs
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Stripe;
+
+namespace TrackHive.Services;
+
+public interface IStripePriceLookupService
+{
+    Task<string?> GetPriceIdByLookupKeyAsync(string lookupKey);
+}
+
+public sealed class StripePriceLookupService : IStripePriceLookupService
+{
+    private readonly PriceService _priceService;
+
+    public StripePriceLookupService()
+    {
+        _priceService = new PriceService();
+    }
+
+    public async Task<string?> GetPriceIdByLookupKeyAsync(string lookupKey)
+    {
+        if (string.IsNullOrWhiteSpace(lookupKey))
+        {
+            return null;
+        }
+
+        var options = new PriceListOptions
+        {
+            LookupKeys = new List<string> { lookupKey },
+            Limit = 1
+        };
+
+        var prices = await _priceService.ListAsync(options);
+        return prices.Data.FirstOrDefault()?.Id;
+    }
+}

--- a/TrackHive.Tests/BillingServiceTests.cs
+++ b/TrackHive.Tests/BillingServiceTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TrackHive.Models;
+using TrackHive.Services;
+
+namespace TrackHive.Tests;
+
+[TestClass]
+public class BillingServiceTests
+{
+    [TestMethod]
+    public async Task ResolvePriceIdAsync_ReturnsConfiguredId_WhenValueAlreadyPriceId()
+    {
+        var service = CreateService("price_123", new FakePriceLookupService());
+
+        var priceId = await InvokeResolvePriceIdAsync(service, SubscriptionPlan.Starter);
+
+        Assert.AreEqual("price_123", priceId);
+    }
+
+    [TestMethod]
+    public async Task ResolvePriceIdAsync_UsesLookupService_ForLookupKeys()
+    {
+        var fakeLookup = new FakePriceLookupService();
+        fakeLookup.LookupResults["starter-monthly"] = "price_456";
+        var service = CreateService("starter-monthly", fakeLookup);
+
+        var first = await InvokeResolvePriceIdAsync(service, SubscriptionPlan.Starter);
+        var second = await InvokeResolvePriceIdAsync(service, SubscriptionPlan.Starter);
+
+        Assert.AreEqual("price_456", first);
+        Assert.AreEqual("price_456", second);
+        Assert.AreEqual(1, fakeLookup.CallCount, "Lookup key should be cached after the first resolution.");
+    }
+
+    [TestMethod]
+    public async Task ResolvePriceIdAsync_Throws_WhenLookupKeyMissing()
+    {
+        var fakeLookup = new FakePriceLookupService();
+        var service = CreateService("missing-key", fakeLookup);
+
+        await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            () => InvokeResolvePriceIdAsync(service, SubscriptionPlan.Starter));
+    }
+
+    private static BillingService CreateService(string starterValue, IStripePriceLookupService lookupService)
+    {
+        var options = Options.Create(new StripeOptions
+        {
+            SecretKey = "sk_test_123",
+            Prices = new StripeOptions.StripePriceOptions
+            {
+                Starter = starterValue,
+                Pro = "price_pro",
+                Enterprise = "price_enterprise"
+            }
+        });
+
+        return new BillingService(options, lookupService);
+    }
+
+    private static Task<string> InvokeResolvePriceIdAsync(BillingService service, SubscriptionPlan plan)
+    {
+        var method = typeof(BillingService).GetMethod(
+            "ResolvePriceIdAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("ResolvePriceIdAsync method not found.");
+
+        var task = method.Invoke(service, new object[] { plan }) as Task<string>
+            ?? throw new InvalidOperationException("ResolvePriceIdAsync did not return a Task<string>.");
+
+        return task;
+    }
+
+    private sealed class FakePriceLookupService : IStripePriceLookupService
+    {
+        public Dictionary<string, string?> LookupResults { get; } = new();
+
+        public int CallCount { get; private set; }
+
+        public Task<string?> GetPriceIdByLookupKeyAsync(string lookupKey)
+        {
+            CallCount++;
+            LookupResults.TryGetValue(lookupKey, out var value);
+            return Task.FromResult(value);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow configuring Stripe prices via lookup keys by resolving them to IDs before creating checkout sessions
- cache resolved price IDs and share a reusable lookup service wired into DI
- cover lookup behaviour with unit tests for `BillingService`

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d3c68e466483288cd2a4c93479f99a