### PR TITLE
Improve Stripe checkout error reporting and sync plan updates

### DIFF
--- a/Controllers/BillingController.cs
+++ b/Controllers/BillingController.cs
@@ -125,12 +125,13 @@ public sealed class BillingController : Controller
         catch (StripeException ex)
         {
             _logger.LogError(ex, "Failed to create Stripe checkout session for organization {OrgId}", orgId);
-            TempData["Error"] = "We couldn't start the checkout session. Please try again.";
+            var reason = ex.StripeError?.Message ?? ex.Message;
+            TempData["Error"] = $"We couldn't start the checkout session. {reason}";
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to start billing upgrade for organization {OrgId}", orgId);
-            TempData["Error"] = "Something went wrong while starting the checkout. Please try again.";
+            TempData["Error"] = $"Something went wrong while starting the checkout: {ex.Message}";
         }
 
         return RedirectToAction(nameof(Upgrade));
@@ -212,19 +213,88 @@ public sealed class BillingController : Controller
             return RedirectToAction(nameof(Failed));
         }
 
-        var plan = TryGetPlan(session.Metadata, out var parsedPlan) ? parsedPlan : SubscriptionPlan.Starter;
-
-        var orgId = GetOrgId();
-        var org = await _db.Organizations.AsNoTracking().FirstOrDefaultAsync(o => o.Id == orgId);
-        if (org is not null)
+        Subscription? subscription = session.Subscription as Subscription;
+        if (subscription is null && !string.IsNullOrWhiteSpace(session.SubscriptionId))
         {
-            ViewData["OrgName"] = org.Name;
+            subscription = await _billing.GetSubscriptionAsync(session.SubscriptionId);
         }
 
-        DateTime? renewsAt = null;
-        if (session.Subscription is Subscription subscription)
+        var metadataOrgId = TryGetOrganizationId(session.Metadata, out var parsedOrgId) ? parsedOrgId : (int?)null;
+        var fallbackOrgId = GetOrgId();
+        var resolvedOrgId = metadataOrgId ?? (fallbackOrgId > 0 ? fallbackOrgId : (int?)null);
+
+        if (metadataOrgId is null && fallbackOrgId > 0)
         {
-            renewsAt = NormalizeToUtc(GetSubscriptionPeriodEnd(subscription));
+            _logger.LogInformation(
+                "Checkout session {SessionId} missing organization metadata. Falling back to authenticated organization {OrgId}.",
+                session.Id,
+                fallbackOrgId);
+        }
+        else if (metadataOrgId is not null && fallbackOrgId > 0 && metadataOrgId.Value != fallbackOrgId)
+        {
+            _logger.LogWarning(
+                "Checkout session {SessionId} metadata organization {MetadataOrgId} differs from authenticated organization {OrgId}.",
+                session.Id,
+                metadataOrgId.Value,
+                fallbackOrgId);
+        }
+
+        if (resolvedOrgId is null)
+        {
+            TempData["Error"] = "We couldn't determine which organization to update.";
+            return RedirectToAction(nameof(Failed));
+        }
+
+        var orgSnapshot = await _db.Organizations.AsNoTracking().FirstOrDefaultAsync(o => o.Id == resolvedOrgId.Value);
+        if (orgSnapshot is not null)
+        {
+            ViewData["OrgName"] = orgSnapshot.Name;
+        }
+
+        var fallbackPlan = orgSnapshot?.SubscriptionPlan ?? SubscriptionPlan.Starter;
+        var plan = TryGetPlan(session.Metadata, out var parsedPlan)
+            ? parsedPlan
+            : ResolvePlanFromSubscription(subscription, fallbackPlan);
+
+        DateTime? renewsAt = NormalizeToUtc(GetSubscriptionPeriodEnd(subscription));
+
+        var updateSucceeded = true;
+        try
+        {
+            await UpdateOrganizationSubscriptionAsync(
+                resolvedOrgId.Value,
+                plan,
+                session.CustomerId,
+                subscription?.Id ?? session.SubscriptionId,
+                renewsAt);
+        }
+        catch (Exception ex)
+        {
+            updateSucceeded = false;
+            _logger.LogError(ex, "Failed to persist subscription upgrade for organization {OrgId} from session {SessionId}.", resolvedOrgId.Value, session.Id);
+            TempData["Warning"] = "Payment succeeded but we couldn't sync your organization automatically. Please contact support.";
+        }
+
+        if (updateSucceeded)
+        {
+            var updatedOrg = await _db.Organizations.AsNoTracking().FirstOrDefaultAsync(o => o.Id == resolvedOrgId.Value);
+            if (updatedOrg is not null)
+            {
+                plan = updatedOrg.SubscriptionPlan;
+                ViewData["OrgName"] = updatedOrg.Name;
+                if (updatedOrg.SubscriptionRenewsAt.HasValue)
+                {
+                    renewsAt = NormalizeToUtc(updatedOrg.SubscriptionRenewsAt);
+                }
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Organization {OrgId} was not found after processing checkout session {SessionId}.",
+                    resolvedOrgId.Value,
+                    session.Id);
+                TempData["Warning"] = "Payment succeeded but we couldn't sync your organization automatically. Please contact support.";
+            }
         }
 
         var vm = new BillingStatusViewModel

--- a/Program.cs
+++ b/Program.cs
@@ -44,6 +44,7 @@ builder.Services.AddHostedService<DataRetentionService>();
 builder.Services.AddScoped<SubscriptionUsageService>();
 
 builder.Services.Configure<StripeOptions>(builder.Configuration.GetSection("Stripe"));
+builder.Services.AddSingleton<IStripePriceLookupService, StripePriceLookupService>();
 builder.Services.AddSingleton<BillingService>();
 
 

--- a/Services/BillingService.cs
+++ b/Services/BillingService.cs
@@ -1,8 +1,10 @@
 // File: Services/BillingService.cs
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Stripe;
 using Stripe.Checkout;
@@ -15,9 +17,15 @@ public sealed class BillingService
     private readonly StripeOptions _options;
     private readonly SessionService _sessionService;
     private readonly SubscriptionService _subscriptionService;
-    private readonly IReadOnlyDictionary<SubscriptionPlan, string> _priceLookup;
+    private readonly IReadOnlyDictionary<SubscriptionPlan, string> _configuredPrices;
+    private readonly IStripePriceLookupService _priceLookupService;
+    private readonly ConcurrentDictionary<string, string> _priceIdCache = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ILogger<BillingService> _logger;
 
-    public BillingService(IOptions<StripeOptions> optionsAccessor)
+    public BillingService(
+        IOptions<StripeOptions> optionsAccessor,
+        IStripePriceLookupService priceLookupService,
+        ILogger<BillingService> logger)
     {
         _options = optionsAccessor?.Value ?? throw new ArgumentNullException(nameof(optionsAccessor));
 
@@ -27,7 +35,9 @@ public sealed class BillingService
         }
 
         StripeConfiguration.ApiKey = _options.SecretKey;
-        _priceLookup = _options.Prices.AsDictionary();
+        _configuredPrices = _options.Prices.AsDictionary();
+        _priceLookupService = priceLookupService ?? throw new ArgumentNullException(nameof(priceLookupService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _sessionService = new SessionService();
         _subscriptionService = new SubscriptionService();
     }
@@ -39,10 +49,7 @@ public sealed class BillingService
         string successUrl,
         string cancelUrl)
     {
-        if (!_priceLookup.TryGetValue(plan, out var priceId) || string.IsNullOrWhiteSpace(priceId))
-        {
-            throw new InvalidOperationException($"Stripe price ID is not configured for plan '{plan}'.");
-        }
+        var priceId = await ResolvePriceIdAsync(plan);
 
         var metadata = new Dictionary<string, string>
         {
@@ -120,4 +127,39 @@ public sealed class BillingService
     }
 
     public string GetPublishableKey() => _options.PublishableKey;
+
+    private async Task<string> ResolvePriceIdAsync(SubscriptionPlan plan)
+    {
+        if (!_configuredPrices.TryGetValue(plan, out var configuredValue) || string.IsNullOrWhiteSpace(configuredValue))
+        {
+            throw new InvalidOperationException($"Stripe price ID is not configured for plan '{plan}'.");
+        }
+
+        if (_priceIdCache.TryGetValue(configuredValue, out var cached))
+        {
+            return cached;
+        }
+
+        if (configuredValue.StartsWith("price_", StringComparison.OrdinalIgnoreCase))
+        {
+            if (await _priceLookupService.PriceExistsAsync(configuredValue))
+            {
+                _priceIdCache[configuredValue] = configuredValue;
+                return configuredValue;
+            }
+
+            _logger.LogWarning(
+                "Stripe price '{ConfiguredValue}' is configured but does not exist. Falling back to lookup key resolution.",
+                configuredValue);
+        }
+
+        var priceId = await _priceLookupService.GetPriceIdByLookupKeyAsync(configuredValue);
+        if (string.IsNullOrWhiteSpace(priceId))
+        {
+            throw new InvalidOperationException($"Stripe price lookup key '{configuredValue}' is not associated with a price.");
+        }
+
+        _priceIdCache[configuredValue] = priceId;
+        return priceId;
+    }
 }

--- a/Services/StripePriceLookupService.cs
+++ b/Services/StripePriceLookupService.cs
@@ -1,0 +1,69 @@
+// File: Services/StripePriceLookupService.cs
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Stripe;
+
+namespace TrackHive.Services;
+
+public interface IStripePriceLookupService
+{
+    Task<bool> PriceExistsAsync(string priceId);
+    Task<string?> GetPriceIdByLookupKeyAsync(string lookupKey);
+}
+
+public sealed class StripePriceLookupService : IStripePriceLookupService
+{
+    private readonly PriceService _priceService;
+
+    public StripePriceLookupService()
+    {
+        _priceService = new PriceService();
+    }
+
+    public async Task<bool> PriceExistsAsync(string priceId)
+    {
+        if (string.IsNullOrWhiteSpace(priceId))
+        {
+            return false;
+        }
+
+        try
+        {
+            var price = await _priceService.GetAsync(priceId);
+            return price is not null;
+        }
+        catch (StripeException ex) when (IsMissingResource(ex))
+        {
+            return false;
+        }
+    }
+
+    public async Task<string?> GetPriceIdByLookupKeyAsync(string lookupKey)
+    {
+        if (string.IsNullOrWhiteSpace(lookupKey))
+        {
+            return null;
+        }
+
+        var options = new PriceListOptions
+        {
+            LookupKeys = new List<string> { lookupKey },
+            Limit = 1
+        };
+
+        var prices = await _priceService.ListAsync(options);
+        return prices.Data.FirstOrDefault()?.Id;
+    }
+
+    private static bool IsMissingResource(StripeException ex)
+    {
+        if (ex.HttpStatusCode == HttpStatusCode.NotFound)
+        {
+            return true;
+        }
+
+        return string.Equals(ex.StripeError?.Code, "resource_missing", System.StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/TrackHive.Tests/BillingServiceTests.cs
+++ b/TrackHive.Tests/BillingServiceTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TrackHive.Models;
+using TrackHive.Services;
+
+namespace TrackHive.Tests;
+
+[TestClass]
+public class BillingServiceTests
+{
+    [TestMethod]
+    public async Task ResolvePriceIdAsync_ReturnsConfiguredId_WhenValueAlreadyPriceId()
+    {
+        var fakeLookup = new FakePriceLookupService();
+        fakeLookup.PriceExistence["price_123"] = true;
+        var service = CreateService("price_123", fakeLookup);
+
+        var priceId = await InvokeResolvePriceIdAsync(service, SubscriptionPlan.Starter);
+
+        Assert.AreEqual("price_123", priceId);
+        Assert.AreEqual(1, fakeLookup.PriceExistsCallCount);
+        Assert.AreEqual(0, fakeLookup.LookupCallCount);
+    }
+
+    [TestMethod]
+    public async Task ResolvePriceIdAsync_UsesLookupService_ForLookupKeys()
+    {
+        var fakeLookup = new FakePriceLookupService();
+        fakeLookup.LookupResults["starter-monthly"] = "price_456";
+        var service = CreateService("starter-monthly", fakeLookup);
+
+        var first = await InvokeResolvePriceIdAsync(service, SubscriptionPlan.Starter);
+        var second = await InvokeResolvePriceIdAsync(service, SubscriptionPlan.Starter);
+
+        Assert.AreEqual("price_456", first);
+        Assert.AreEqual("price_456", second);
+        Assert.AreEqual(1, fakeLookup.LookupCallCount, "Lookup key should be cached after the first resolution.");
+    }
+
+    [TestMethod]
+    public async Task ResolvePriceIdAsync_Throws_WhenLookupKeyMissing()
+    {
+        var fakeLookup = new FakePriceLookupService();
+        var service = CreateService("missing-key", fakeLookup);
+
+        await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            () => InvokeResolvePriceIdAsync(service, SubscriptionPlan.Starter));
+    }
+
+    private static BillingService CreateService(string starterValue, IStripePriceLookupService lookupService)
+    {
+        var options = Options.Create(new StripeOptions
+        {
+            SecretKey = "sk_test_123",
+            Prices = new StripeOptions.StripePriceOptions
+            {
+                Starter = starterValue,
+                Pro = "price_pro",
+                Enterprise = "price_enterprise"
+            }
+        });
+
+        return new BillingService(options, lookupService, NullLogger<BillingService>.Instance);
+    }
+
+    private static Task<string> InvokeResolvePriceIdAsync(BillingService service, SubscriptionPlan plan)
+    {
+        var method = typeof(BillingService).GetMethod(
+            "ResolvePriceIdAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("ResolvePriceIdAsync method not found.");
+
+        var task = method.Invoke(service, new object[] { plan }) as Task<string>
+            ?? throw new InvalidOperationException("ResolvePriceIdAsync did not return a Task<string>.");
+
+        return task;
+    }
+
+    private sealed class FakePriceLookupService : IStripePriceLookupService
+    {
+        public Dictionary<string, string?> LookupResults { get; } = new();
+        public Dictionary<string, bool> PriceExistence { get; } = new();
+
+        public int LookupCallCount { get; private set; }
+        public int PriceExistsCallCount { get; private set; }
+
+        public Task<bool> PriceExistsAsync(string priceId)
+        {
+            PriceExistsCallCount++;
+            return Task.FromResult(PriceExistence.TryGetValue(priceId, out var exists) && exists);
+        }
+
+        public Task<string?> GetPriceIdByLookupKeyAsync(string lookupKey)
+        {
+            LookupCallCount++;
+            LookupResults.TryGetValue(lookupKey, out var value);
+            return Task.FromResult(value);
+        }
+    }
+}

--- a/Views/Billing/Success.cshtml
+++ b/Views/Billing/Success.cshtml
@@ -15,6 +15,13 @@
                 <h1 class="h3 mb-3">@Model.Title</h1>
                 <p class="lead mb-4">@Model.Message</p>
 
+                @if (TempData["Warning"] is string warning && !string.IsNullOrWhiteSpace(warning))
+                {
+                    <div class="alert alert-warning" role="alert">
+                        @warning
+                    </div>
+                }
+
                 <div class="alert alert-success" role="status">
                     <strong>@planName</strong> features are now unlocked for <strong>@orgName</strong>.
                 </div>


### PR DESCRIPTION
## Summary
- surface Stripe error details when checkout fails and log metadata inconsistencies during success handling
- validate configured price identifiers before checkout, fallback to lookup keys when needed, and update the organization immediately after a successful session
- extend Stripe price lookup service plus unit tests and success view messaging to cover the new behaviors

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d3c68e466483288cd2a4c93479f99a