### PR TITLE
Update Stripe price lookup keys

### DIFF
--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -10,9 +10,9 @@
     "SecretKey": "sk_test_51SApNlAFX0bedAqppSPYt7zxbwdoDTv6KtlcDtWW6TuAfGCIfCKh3GTn54TopBqFbAz46yN9DNXo9ljs6Pg8p9mb0070Eah0pP",
     "WebhookSecret": "whsec_example",
     "Prices": {
-      "Starter": "price_starter",
-      "Pro": "price_pro",
-      "Enterprise": "price_enterprise"
+      "Starter": "starter-monthly",
+      "Pro": "pro-monthly",
+      "Enterprise": "enterprise-monthly"
     }
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -22,9 +22,9 @@
     "SecretKey": "sk_test_51SApNlAFX0bedAqppSPYt7zxbwdoDTv6KtlcDtWW6TuAfGCIfCKh3GTn54TopBqFbAz46yN9DNXo9ljs6Pg8p9mb0070Eah0pP",
     "WebhookSecret": "whsec_example",
     "Prices": {
-      "Starter": "price_starter",
-      "Pro": "price_pro",
-      "Enterprise": "price_enterprise"
+      "Starter": "starter-monthly",
+      "Pro": "pro-monthly",
+      "Enterprise": "enterprise-monthly"
     }
   }
 }


### PR DESCRIPTION
## Summary
- replace placeholder Stripe price identifiers with the starter/pro/enterprise lookup keys in configuration

## Testing
- dotnet test *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3cd2d44d48328a9ffa5f5123052be