### PR TITLE
Simplify billing price resolution

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -44,7 +44,6 @@ builder.Services.AddHostedService<DataRetentionService>();
 builder.Services.AddScoped<SubscriptionUsageService>();
 
 builder.Services.Configure<StripeOptions>(builder.Configuration.GetSection("Stripe"));
-builder.Services.AddSingleton<IStripePriceLookupService, StripePriceLookupService>();
 builder.Services.AddSingleton<BillingService>();
 
 

--- a/Services/BillingService.cs
+++ b/Services/BillingService.cs
@@ -1,6 +1,5 @@
 // File: Services/BillingService.cs
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
@@ -18,14 +17,11 @@ public sealed class BillingService
     private readonly SessionService _sessionService;
     private readonly SubscriptionService _subscriptionService;
     private readonly IReadOnlyDictionary<SubscriptionPlan, string> _configuredPrices;
-    private readonly IStripePriceLookupService _priceLookupService;
-    private readonly ConcurrentDictionary<string, string> _priceIdCache = new(StringComparer.OrdinalIgnoreCase);
 
     private readonly ILogger<BillingService> _logger;
 
     public BillingService(
         IOptions<StripeOptions> optionsAccessor,
-        IStripePriceLookupService priceLookupService,
         ILogger<BillingService> logger)
 
     {
@@ -38,7 +34,6 @@ public sealed class BillingService
 
         StripeConfiguration.ApiKey = _options.SecretKey;
         _configuredPrices = _options.Prices.AsDictionary();
-        _priceLookupService = priceLookupService ?? throw new ArgumentNullException(nameof(priceLookupService));
 
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
@@ -132,38 +127,15 @@ public sealed class BillingService
 
     public string GetPublishableKey() => _options.PublishableKey;
 
-    private async Task<string> ResolvePriceIdAsync(SubscriptionPlan plan)
+    private Task<string> ResolvePriceIdAsync(SubscriptionPlan plan)
     {
         if (!_configuredPrices.TryGetValue(plan, out var configuredValue) || string.IsNullOrWhiteSpace(configuredValue))
         {
             throw new InvalidOperationException($"Stripe price ID is not configured for plan '{plan}'.");
         }
 
-        if (_priceIdCache.TryGetValue(configuredValue, out var cached))
-        {
-            return cached;
-        }
+        _logger.LogDebug("Using configured Stripe price ID {PriceId} for plan {Plan}.", configuredValue, plan);
 
-        if (configuredValue.StartsWith("price_", StringComparison.OrdinalIgnoreCase))
-        {
-            if (await _priceLookupService.PriceExistsAsync(configuredValue))
-            {
-                _priceIdCache[configuredValue] = configuredValue;
-                return configuredValue;
-            }
-
-            _logger.LogWarning(
-                "Stripe price '{ConfiguredValue}' is configured but does not exist. Falling back to lookup key resolution.",
-                configuredValue);
-        }
-
-        var priceId = await _priceLookupService.GetPriceIdByLookupKeyAsync(configuredValue);
-        if (string.IsNullOrWhiteSpace(priceId))
-        {
-            throw new InvalidOperationException($"Stripe price lookup key '{configuredValue}' is not associated with a price.");
-        }
-
-        _priceIdCache[configuredValue] = priceId;
-        return priceId;
+        return Task.FromResult(configuredValue);
     }
 }

--- a/TrackHive.Tests/BillingServiceTests.cs
+++ b/TrackHive.Tests/BillingServiceTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -16,49 +15,39 @@ namespace TrackHive.Tests;
 public class BillingServiceTests
 {
     [TestMethod]
-    public async Task ResolvePriceIdAsync_ReturnsConfiguredId_WhenValueAlreadyPriceId()
+    public async Task ResolvePriceIdAsync_ReturnsConfiguredId_ForConfiguredPlan()
     {
-
-        var fakeLookup = new FakePriceLookupService();
-        fakeLookup.PriceExistence["price_123"] = true;
-        var service = CreateService("price_123", fakeLookup);
-
+        var service = CreateService("price_123");
 
         var priceId = await InvokeResolvePriceIdAsync(service, SubscriptionPlan.Starter);
 
         Assert.AreEqual("price_123", priceId);
-        Assert.AreEqual(1, fakeLookup.PriceExistsCallCount);
-        Assert.AreEqual(0, fakeLookup.LookupCallCount);
-
     }
 
     [TestMethod]
-    public async Task ResolvePriceIdAsync_UsesLookupService_ForLookupKeys()
+    public async Task ResolvePriceIdAsync_ReturnsConfiguredId_ForDifferentPlans()
     {
-        var fakeLookup = new FakePriceLookupService();
-        fakeLookup.LookupResults["starter-monthly"] = "price_456";
-        var service = CreateService("starter-monthly", fakeLookup);
+        var service = CreateService("price_starter");
 
-        var first = await InvokeResolvePriceIdAsync(service, SubscriptionPlan.Starter);
-        var second = await InvokeResolvePriceIdAsync(service, SubscriptionPlan.Starter);
+        var starter = await InvokeResolvePriceIdAsync(service, SubscriptionPlan.Starter);
+        var pro = await InvokeResolvePriceIdAsync(service, SubscriptionPlan.Pro);
+        var enterprise = await InvokeResolvePriceIdAsync(service, SubscriptionPlan.Enterprise);
 
-        Assert.AreEqual("price_456", first);
-        Assert.AreEqual("price_456", second);
-        Assert.AreEqual(1, fakeLookup.LookupCallCount, "Lookup key should be cached after the first resolution.");
-
+        Assert.AreEqual("price_starter", starter);
+        Assert.AreEqual("price_pro", pro);
+        Assert.AreEqual("price_enterprise", enterprise);
     }
 
     [TestMethod]
-    public async Task ResolvePriceIdAsync_Throws_WhenLookupKeyMissing()
+    public async Task ResolvePriceIdAsync_Throws_WhenPriceNotConfigured()
     {
-        var fakeLookup = new FakePriceLookupService();
-        var service = CreateService("missing-key", fakeLookup);
+        var service = CreateService(string.Empty);
 
         await Assert.ThrowsExceptionAsync<InvalidOperationException>(
             () => InvokeResolvePriceIdAsync(service, SubscriptionPlan.Starter));
     }
 
-    private static BillingService CreateService(string starterValue, IStripePriceLookupService lookupService)
+    private static BillingService CreateService(string starterValue)
     {
         var options = Options.Create(new StripeOptions
         {
@@ -71,9 +60,7 @@ public class BillingServiceTests
             }
         });
 
-
-        return new BillingService(options, lookupService, NullLogger<BillingService>.Instance);
-
+        return new BillingService(options, NullLogger<BillingService>.Instance);
     }
 
     private static Task<string> InvokeResolvePriceIdAsync(BillingService service, SubscriptionPlan plan)
@@ -87,27 +74,5 @@ public class BillingServiceTests
             ?? throw new InvalidOperationException("ResolvePriceIdAsync did not return a Task<string>.");
 
         return task;
-    }
-
-    private sealed class FakePriceLookupService : IStripePriceLookupService
-    {
-        public Dictionary<string, string?> LookupResults { get; } = new();
-        public Dictionary<string, bool> PriceExistence { get; } = new();
-
-        public int LookupCallCount { get; private set; }
-        public int PriceExistsCallCount { get; private set; }
-
-        public Task<bool> PriceExistsAsync(string priceId)
-        {
-            PriceExistsCallCount++;
-            return Task.FromResult(PriceExistence.TryGetValue(priceId, out var exists) && exists);
-        }
-
-        public Task<string?> GetPriceIdByLookupKeyAsync(string lookupKey)
-        {
-            LookupCallCount++;
-            LookupResults.TryGetValue(lookupKey, out var value);
-            return Task.FromResult(value);
-        }
     }
 }


### PR DESCRIPTION
## Summary
- resolve Stripe prices directly from configuration without lookup indirection
- remove the unused Stripe price lookup service registration
- refresh billing service unit tests to cover direct price configuration behavior

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d1ebbb0883289de5548cb3131da8