### PR TITLE
Hardcode subscription plan pricing

### DIFF
--- a/Controllers/BillingController.cs
+++ b/Controllers/BillingController.cs
@@ -481,6 +481,11 @@ public sealed class BillingController : Controller
             return fallback;
         }
 
+        if (TryGetPlan(subscription.Metadata, out var planFromMetadata))
+        {
+            return planFromMetadata;
+        }
+
         var priceId = subscription.Items?.Data?.FirstOrDefault()?.Price?.Id;
         return ResolvePlanFromPriceId(priceId, fallback);
     }

--- a/Models/SubscriptionPlanExtensions.cs
+++ b/Models/SubscriptionPlanExtensions.cs
@@ -42,7 +42,7 @@ public static class SubscriptionPlanExtensions
             [SubscriptionPlan.Enterprise] = new(
                 "Enterprise",
                 "Enterprise-grade compliance and onboarding at scale.",
-                "Custom pricing",
+                "$399/mo",
                 new[]
                 {
                     "Dedicated success manager",

--- a/Services/BillingService.cs
+++ b/Services/BillingService.cs
@@ -13,10 +13,20 @@ namespace TrackHive.Services;
 
 public sealed class BillingService
 {
+    private const string BillingCurrency = "usd";
+    private const string BillingInterval = "month";
+
+    private static readonly IReadOnlyDictionary<SubscriptionPlan, long> PlanAmounts =
+        new Dictionary<SubscriptionPlan, long>
+        {
+            [SubscriptionPlan.Starter] = 99_00L,
+            [SubscriptionPlan.Pro] = 199_00L,
+            [SubscriptionPlan.Enterprise] = 399_00L
+        };
+
     private readonly StripeOptions _options;
     private readonly SessionService _sessionService;
     private readonly SubscriptionService _subscriptionService;
-    private readonly IReadOnlyDictionary<SubscriptionPlan, string> _configuredPrices;
 
     private readonly ILogger<BillingService> _logger;
 
@@ -33,8 +43,6 @@ public sealed class BillingService
         }
 
         StripeConfiguration.ApiKey = _options.SecretKey;
-        _configuredPrices = _options.Prices.AsDictionary();
-
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
         _sessionService = new SessionService();
@@ -48,8 +56,6 @@ public sealed class BillingService
         string successUrl,
         string cancelUrl)
     {
-        var priceId = await ResolvePriceIdAsync(plan);
-
         var metadata = new Dictionary<string, string>
         {
             ["organizationId"] = organizationId.ToString(CultureInfo.InvariantCulture),
@@ -71,11 +77,7 @@ public sealed class BillingService
             },
             LineItems = new List<SessionLineItemOptions>
             {
-                new()
-                {
-                    Price = priceId,
-                    Quantity = 1
-                }
+                CreateSubscriptionLineItem(plan)
             }
         };
 
@@ -127,15 +129,31 @@ public sealed class BillingService
 
     public string GetPublishableKey() => _options.PublishableKey;
 
-    private Task<string> ResolvePriceIdAsync(SubscriptionPlan plan)
+    private SessionLineItemOptions CreateSubscriptionLineItem(SubscriptionPlan plan)
     {
-        if (!_configuredPrices.TryGetValue(plan, out var configuredValue) || string.IsNullOrWhiteSpace(configuredValue))
+        if (!PlanAmounts.TryGetValue(plan, out var amount))
         {
-            throw new InvalidOperationException($"Stripe price ID is not configured for plan '{plan}'.");
+            throw new InvalidOperationException($"No pricing configured for plan '{plan}'.");
         }
 
-        _logger.LogDebug("Using configured Stripe price ID {PriceId} for plan {Plan}.", configuredValue, plan);
+        var displayName = plan.GetDisplayName();
 
-        return Task.FromResult(configuredValue);
+        return new SessionLineItemOptions
+        {
+            Quantity = 1,
+            PriceData = new SessionLineItemPriceDataOptions
+            {
+                Currency = BillingCurrency,
+                UnitAmount = amount,
+                ProductData = new SessionLineItemPriceDataProductDataOptions
+                {
+                    Name = displayName
+                },
+                Recurring = new SessionLineItemPriceDataRecurringOptions
+                {
+                    Interval = BillingInterval
+                }
+            }
+        };
     }
 }

--- a/TrackHive.Tests/BillingServiceTests.cs
+++ b/TrackHive.Tests/BillingServiceTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Reflection;
-using System.Threading.Tasks;
+using System.Runtime.ExceptionServices;
 
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -8,71 +8,73 @@ using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TrackHive.Models;
 using TrackHive.Services;
+using Stripe.Checkout;
 
 namespace TrackHive.Tests;
 
 [TestClass]
 public class BillingServiceTests
 {
-    [TestMethod]
-    public async Task ResolvePriceIdAsync_ReturnsConfiguredId_ForConfiguredPlan()
+    [DataTestMethod]
+    [DataRow(SubscriptionPlan.Starter, 99_00L, "Starter")]
+    [DataRow(SubscriptionPlan.Pro, 199_00L, "Pro")]
+    [DataRow(SubscriptionPlan.Enterprise, 399_00L, "Enterprise")]
+    public void CreateSubscriptionLineItem_ConfiguresExpectedPricing(
+        SubscriptionPlan plan,
+        long expectedAmount,
+        string expectedName)
     {
-        var service = CreateService("price_123");
+        var service = CreateService();
 
-        var priceId = await InvokeResolvePriceIdAsync(service, SubscriptionPlan.Starter);
+        var lineItem = InvokeCreateSubscriptionLineItem(service, plan);
 
-        Assert.AreEqual("price_123", priceId);
+        Assert.AreEqual(1, lineItem.Quantity);
+        Assert.IsNotNull(lineItem.PriceData);
+        Assert.AreEqual("usd", lineItem.PriceData.Currency);
+        Assert.AreEqual(expectedAmount, lineItem.PriceData.UnitAmount);
+        Assert.IsNotNull(lineItem.PriceData.ProductData);
+        Assert.AreEqual(expectedName, lineItem.PriceData.ProductData.Name);
+        Assert.IsNotNull(lineItem.PriceData.Recurring);
+        Assert.AreEqual("month", lineItem.PriceData.Recurring.Interval);
     }
 
     [TestMethod]
-    public async Task ResolvePriceIdAsync_ReturnsConfiguredId_ForDifferentPlans()
+    public void CreateSubscriptionLineItem_ThrowsForUnsupportedPlan()
     {
-        var service = CreateService("price_starter");
+        var service = CreateService();
 
-        var starter = await InvokeResolvePriceIdAsync(service, SubscriptionPlan.Starter);
-        var pro = await InvokeResolvePriceIdAsync(service, SubscriptionPlan.Pro);
-        var enterprise = await InvokeResolvePriceIdAsync(service, SubscriptionPlan.Enterprise);
-
-        Assert.AreEqual("price_starter", starter);
-        Assert.AreEqual("price_pro", pro);
-        Assert.AreEqual("price_enterprise", enterprise);
+        Assert.ThrowsException<InvalidOperationException>(
+            () => InvokeCreateSubscriptionLineItem(service, SubscriptionPlan.Free));
     }
 
-    [TestMethod]
-    public async Task ResolvePriceIdAsync_Throws_WhenPriceNotConfigured()
-    {
-        var service = CreateService(string.Empty);
-
-        await Assert.ThrowsExceptionAsync<InvalidOperationException>(
-            () => InvokeResolvePriceIdAsync(service, SubscriptionPlan.Starter));
-    }
-
-    private static BillingService CreateService(string starterValue)
+    private static BillingService CreateService()
     {
         var options = Options.Create(new StripeOptions
         {
-            SecretKey = "sk_test_123",
-            Prices = new StripeOptions.StripePriceOptions
-            {
-                Starter = starterValue,
-                Pro = "price_pro",
-                Enterprise = "price_enterprise"
-            }
+            SecretKey = "sk_test_123"
         });
 
         return new BillingService(options, NullLogger<BillingService>.Instance);
     }
 
-    private static Task<string> InvokeResolvePriceIdAsync(BillingService service, SubscriptionPlan plan)
+    private static SessionLineItemOptions InvokeCreateSubscriptionLineItem(
+        BillingService service,
+        SubscriptionPlan plan)
     {
         var method = typeof(BillingService).GetMethod(
-            "ResolvePriceIdAsync",
+            "CreateSubscriptionLineItem",
             BindingFlags.Instance | BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException("ResolvePriceIdAsync method not found.");
+            ?? throw new InvalidOperationException("CreateSubscriptionLineItem method not found.");
 
-        var task = method.Invoke(service, new object[] { plan }) as Task<string>
-            ?? throw new InvalidOperationException("ResolvePriceIdAsync did not return a Task<string>.");
-
-        return task;
+        try
+        {
+            return method.Invoke(service, new object[] { plan }) as SessionLineItemOptions
+                ?? throw new InvalidOperationException("CreateSubscriptionLineItem did not return a SessionLineItemOptions.");
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            throw;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace Stripe price ID usage with hardcoded USD monthly amounts for paid plans
- fallback to subscription metadata when resolving plans from webhook/session payloads
- adjust enterprise plan display copy and update billing service unit tests for the new pricing logic

## Testing
- MSBUILDTERMINALLOGGER=false dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d3d4247f448328801dc2e156fe6fc4