### PR TITLE
Allow configuring Stripe success redirect host

### DIFF
--- a/Controllers/BillingController.cs
+++ b/Controllers/BillingController.cs
@@ -99,18 +99,10 @@ public sealed class BillingController : Controller
 
         try
         {
-            var successUrl = Url.Action(nameof(Success), "Billing", values: null, protocol: Request.Scheme, host: Request.Host.ToString());
-            if (string.IsNullOrWhiteSpace(successUrl))
-            {
-                throw new InvalidOperationException("Unable to resolve the success URL.");
-            }
+            var successUrl = BuildCheckoutRedirectUrl(Url.Action(nameof(Success), "Billing"));
             successUrl = AppendCheckoutSessionId(successUrl);
 
-            var cancelUrl = Url.Action(nameof(Failed), "Billing", new { plan }, Request.Scheme, Request.Host.ToString());
-            if (string.IsNullOrWhiteSpace(cancelUrl))
-            {
-                throw new InvalidOperationException("Unable to resolve the cancel URL.");
-            }
+            var cancelUrl = BuildCheckoutRedirectUrl(Url.Action(nameof(Failed), "Billing", new { plan }));
 
             var email = User.FindFirstValue(ClaimTypes.Email);
             var session = await _billing.CreateCheckoutSessionAsync(org.Id, plan, email, successUrl, cancelUrl);
@@ -356,6 +348,60 @@ public sealed class BillingController : Controller
 
         var separator = withoutFragment.Contains('?', StringComparison.Ordinal) ? '&' : '?';
         return $"{withoutFragment}{separator}session_id={{CHECKOUT_SESSION_ID}}{fragment}";
+    }
+
+    private string BuildCheckoutRedirectUrl(string? pathOrAbsolute)
+    {
+        if (string.IsNullOrWhiteSpace(pathOrAbsolute))
+        {
+            throw new InvalidOperationException("Unable to resolve the checkout redirect URL.");
+        }
+
+        if (Uri.TryCreate(pathOrAbsolute, UriKind.Absolute, out var absolute))
+        {
+            return absolute.ToString();
+        }
+
+        var baseUri = ResolveCheckoutBaseUri();
+        var relative = pathOrAbsolute.TrimStart('/');
+        return new Uri(baseUri, relative).ToString();
+    }
+
+    private Uri ResolveCheckoutBaseUri()
+    {
+        if (!string.IsNullOrWhiteSpace(_stripeOptions.CheckoutRedirectBaseUrl))
+        {
+            var configuredBase = EnsureTrailingSlash(_stripeOptions.CheckoutRedirectBaseUrl);
+            if (!Uri.TryCreate(configuredBase, UriKind.Absolute, out var baseUri))
+            {
+                throw new InvalidOperationException("Configured Stripe checkout redirect base URL is invalid.");
+            }
+
+            return baseUri;
+        }
+
+        var request = HttpContext?.Request
+            ?? throw new InvalidOperationException("Unable to determine the current HTTP request.");
+
+        if (string.IsNullOrEmpty(request.Scheme) || !request.Host.HasValue)
+        {
+            throw new InvalidOperationException("Unable to determine the current request host.");
+        }
+
+        var hostUrl = EnsureTrailingSlash($"{request.Scheme}://{request.Host.Value}");
+        return new Uri(hostUrl, UriKind.Absolute);
+    }
+
+    private static string EnsureTrailingSlash(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            throw new ArgumentException("URL cannot be null or whitespace.", nameof(url));
+        }
+
+        return url.EndsWith('/', StringComparison.Ordinal)
+            ? url
+            : url + "/";
     }
 
     private async Task HandleCheckoutSessionAsync(Session session)

--- a/Models/StripeOptions.cs
+++ b/Models/StripeOptions.cs
@@ -8,6 +8,13 @@ public sealed class StripeOptions
     public string PublishableKey { get; set; } = string.Empty;
     public string SecretKey { get; set; } = string.Empty;
     public string WebhookSecret { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional base URL used to build Stripe success/cancel redirects.
+    /// When not provided the application falls back to the current HTTP request.
+    /// </summary>
+    public string? CheckoutRedirectBaseUrl { get; set; }
+
     public StripePriceOptions Prices { get; set; } = new();
 
     public sealed class StripePriceOptions

--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ Set your connection string and SMTP in `appsettings.json` (or via user secrets /
 }
 ```
 
+When testing Stripe locally behind tunnels or custom ports, you can override the redirect host with `Stripe.CheckoutRedirectBaseUrl`:
+
+```json
+{
+  "Stripe": {
+    "CheckoutRedirectBaseUrl": "http://localhost:5078"
+  }
+}
+```
+
 ---
 
 ## 🚀 Quick Start

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -9,6 +9,7 @@
     "PublishableKey": "pk_test_51SApNlAFX0bedAqpSrb5kSdTkVwl7rzFsz3JqQ5GOR1VHkzIXOQA9J6snezfH2her4orXFD1Rmid3xX2WNejIZXO00PJTogEHK",
     "SecretKey": "sk_test_51SApNlAFX0bedAqppSPYt7zxbwdoDTv6KtlcDtWW6TuAfGCIfCKh3GTn54TopBqFbAz46yN9DNXo9ljs6Pg8p9mb0070Eah0pP",
     "WebhookSecret": "whsec_example",
+    "CheckoutRedirectBaseUrl": "",
     "Prices": {
       "Starter": "starter-monthly",
       "Pro": "pro-monthly",

--- a/appsettings.json
+++ b/appsettings.json
@@ -21,6 +21,7 @@
     "PublishableKey": "pk_test_51SApNlAFX0bedAqpSrb5kSdTkVwl7rzFsz3JqQ5GOR1VHkzIXOQA9J6snezfH2her4orXFD1Rmid3xX2WNejIZXO00PJTogEHK",
     "SecretKey": "sk_test_51SApNlAFX0bedAqppSPYt7zxbwdoDTv6KtlcDtWW6TuAfGCIfCKh3GTn54TopBqFbAz46yN9DNXo9ljs6Pg8p9mb0070Eah0pP",
     "WebhookSecret": "whsec_example",
+    "CheckoutRedirectBaseUrl": "",
     "Prices": {
       "Starter": "starter-monthly",
       "Pro": "pro-monthly",


### PR DESCRIPTION
## Summary
- allow the Stripe checkout success/cancel URLs to use an optional configured base URL
- add helpers to consistently build absolute redirect URLs and reuse them when creating checkout sessions
- document the new configuration option and surface it in appsettings files for local overrides

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d3d74767c08328903955613872e119